### PR TITLE
feat(config): native provider env vars, Validate(), migrate to ToolCa…

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,75 +1,54 @@
 # TF-AI Environment Configuration
 # Copy this file to .env and fill in the values for your chosen provider.
 # Never commit .env to source control.
+#
+# Usage: uncomment ONE provider block below and set MODEL_PROVIDER to match.
 
-# ── Model Provider ────────────────────────────────────────────────────────────
-# Select the inference backend: ollama | openai | azure | bedrock | gemini
+# ── Provider selection (required) ─────────────────────────────────────────────
+# ollama | openai | azure | bedrock | gemini
 MODEL_PROVIDER=ollama
 
-# Model name or deployment ID
-MODEL_NAME=llama3
-
-# Max tokens per response (default: 4096)
-MODEL_MAX_TOKENS=4096
-
-# Temperature 0.0–1.0 (default: 0.2 — low for deterministic code generation)
-MODEL_TEMPERATURE=0.2
+# ── Shared tuning (optional, applies to all providers) ────────────────────────
+# MODEL_MAX_TOKENS=4096       # max tokens per response (default: 4096)
+# MODEL_TEMPERATURE=0.2       # 0.0–1.0, lower = more deterministic (default: 0.2)
 
 # ── Ollama (local) ────────────────────────────────────────────────────────────
-# Only required if MODEL_PROVIDER=ollama
-MODEL_BASE_URL=http://localhost:11434
+# MODEL_PROVIDER=ollama
+OLLAMA_HOST=http://localhost:11434   # default; override if Ollama runs elsewhere
+OLLAMA_MODEL=llama3                  # any model pulled via `ollama pull`
 
 # ── OpenAI ────────────────────────────────────────────────────────────────────
-# Only required if MODEL_PROVIDER=openai
-# Native SDK env var: OPENAI_API_KEY=sk-proj-...
-#
 # MODEL_PROVIDER=openai
-# MODEL_NAME=gpt-4o                        # e.g. gpt-4o, gpt-4o-mini, gpt-4-turbo
-# MODEL_API_KEY=sk-proj-...               # same value as OPENAI_API_KEY
-#
-# One-liner if you already have OPENAI_API_KEY set in your shell:
-# MODEL_API_KEY=${OPENAI_API_KEY}
+# OPENAI_API_KEY=sk-proj-...           # required — https://platform.openai.com/api-keys
+# OPENAI_MODEL=gpt-4o                  # e.g. gpt-4o, gpt-4o-mini, gpt-4-turbo
 
 # ── Azure OpenAI ──────────────────────────────────────────────────────────────
-# Only required if MODEL_PROVIDER=azure
-# Native SDK env vars: AZURE_OPENAI_API_KEY, AZURE_OPENAI_ENDPOINT, AZURE_OPENAI_DEPLOYMENT_NAME
-#
 # MODEL_PROVIDER=azure
-# MODEL_API_KEY=abc123def456...           # same value as AZURE_OPENAI_API_KEY
-# MODEL_BASE_URL=https://my-resource.openai.azure.com/  # same value as AZURE_OPENAI_ENDPOINT
-# AZURE_DEPLOYMENT=gpt-4o-prod           # same value as AZURE_OPENAI_DEPLOYMENT_NAME
-# MODEL_NAME=gpt-4o                       # informational only — deployment name is used
-#
-# One-liner if you already have the Azure SDK vars set in your shell:
-# MODEL_API_KEY=${AZURE_OPENAI_API_KEY}
-# MODEL_BASE_URL=${AZURE_OPENAI_ENDPOINT}
-# AZURE_DEPLOYMENT=${AZURE_OPENAI_DEPLOYMENT_NAME}
+# AZURE_OPENAI_API_KEY=...             # required — Azure portal → your resource → Keys
+# AZURE_OPENAI_ENDPOINT=https://YOUR-RESOURCE.openai.azure.com  # required
+# AZURE_OPENAI_DEPLOYMENT=gpt-4o      # required — your deployment name
+# AZURE_OPENAI_API_VERSION=2024-02-01 # optional, default: 2024-02-01
 
 # ── AWS Bedrock ───────────────────────────────────────────────────────────────
-# Only required if MODEL_PROVIDER=bedrock
-# Native SDK env vars: AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, AWS_SESSION_TOKEN (optional)
-# Credentials are resolved via the standard AWS SDK chain:
-#   1. env vars  2. ~/.aws/credentials  3. instance profile / ECS task role
-#
 # MODEL_PROVIDER=bedrock
-# MODEL_NAME=anthropic.claude-3-5-sonnet-20241022-v2:0  # Bedrock model ID
-# AWS_REGION=us-east-1
+# BEDROCK_MODEL_ID=anthropic.claude-3-5-sonnet-20241022-v2:0  # required
+# AWS_REGION=us-east-1                 # required (default: us-east-1)
 #
-# If using static credentials (not recommended for production):
-# AWS_ACCESS_KEY_ID=AKIA...
+# Credentials are resolved via the standard AWS SDK chain — no key vars needed
+# if you have a configured profile or instance role:
+#   1. AWS_PROFILE (or AWS_ACCESS_KEY_ID + AWS_SECRET_ACCESS_KEY)
+#   2. ~/.aws/credentials
+#   3. ECS task role / EC2 instance profile
+#
+# AWS_PROFILE=my-profile               # optional — select a named profile
+# AWS_ACCESS_KEY_ID=AKIA...            # optional — static credentials (not recommended for prod)
 # AWS_SECRET_ACCESS_KEY=wJalr...
-# AWS_SESSION_TOKEN=AQoX...              # only needed for temporary credentials
+# AWS_SESSION_TOKEN=AQoX...            # optional — for temporary credentials
 
 # ── Google Gemini ─────────────────────────────────────────────────────────────
-# Only required if MODEL_PROVIDER=gemini
-# Native SDK env var: GOOGLE_API_KEY or GEMINI_API_KEY (AI Studio)
-#
 # MODEL_PROVIDER=gemini
-# MODEL_NAME=gemini-1.5-pro              # e.g. gemini-1.5-pro, gemini-1.5-flash, gemini-2.0-flash
-# MODEL_API_KEY=AIza...                  # same value as GOOGLE_API_KEY / GEMINI_API_KEY
-#
-# One-liner if you already have GOOGLE_API_KEY set in your shell:
-# MODEL_API_KEY=${GOOGLE_API_KEY}
+# GOOGLE_API_KEY=AIza...               # required — https://aistudio.google.com/app/apikey
+# GEMINI_MODEL=gemini-1.5-pro          # e.g. gemini-1.5-pro, gemini-1.5-flash, gemini-2.0-flash
 
 # ── Qdrant Vector Store ───────────────────────────────────────────────────────
 QDRANT_HOST=localhost

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -60,17 +60,6 @@ issues:
         - wrapcheck
         - gosec
 
-    # SA1019: model.ChatModel is deprecated in eino — tracked upstream.
-    # We cannot migrate until eino-ext provider constructors return ToolCallingChatModel.
-    - path: "internal/provider/"
-      linters:
-        - staticcheck
-      text: "SA1019"
-    - path: "internal/agent/"
-      linters:
-        - staticcheck
-      text: "SA1019"
-
     # Provider backend constructors are thin pass-throughs to eino-ext — wrapping
     # the constructor error adds no diagnostic value.
     - path: "internal/provider/backends\\.go"

--- a/README.md
+++ b/README.md
@@ -66,17 +66,20 @@ tfai ingest --provider aws \
 
 ## Model Provider Configuration
 
-Set `MODEL_PROVIDER` to select your inference backend. All other config is via env vars.
+Set `MODEL_PROVIDER` to select your inference backend. Each provider uses its own
+native credential env vars — no homogenised `MODEL_API_KEY` abstraction.
 
 | Provider | `MODEL_PROVIDER` | Required env vars |
 |---|---|---|
-| **Ollama** (local) | `ollama` | `MODEL_BASE_URL` (default: `http://localhost:11434`), `MODEL_NAME` |
-| **OpenAI** | `openai` | `MODEL_API_KEY`, `MODEL_NAME` |
-| **Azure OpenAI** | `azure` | `MODEL_API_KEY`, `MODEL_BASE_URL` (endpoint), `AZURE_DEPLOYMENT` |
-| **AWS Bedrock** | `bedrock` | AWS credential chain, `MODEL_NAME`, `AWS_REGION` |
-| **Google Gemini** | `gemini` | `MODEL_API_KEY`, `MODEL_NAME` |
+| **Ollama** (local) | `ollama` | `OLLAMA_HOST` (default: `http://localhost:11434`), `OLLAMA_MODEL` |
+| **OpenAI** | `openai` | `OPENAI_API_KEY`, `OPENAI_MODEL` |
+| **Azure OpenAI** | `azure` | `AZURE_OPENAI_API_KEY`, `AZURE_OPENAI_ENDPOINT`, `AZURE_OPENAI_DEPLOYMENT` |
+| **AWS Bedrock** | `bedrock` | AWS credential chain (`AWS_PROFILE` / env / instance role), `BEDROCK_MODEL_ID`, `AWS_REGION` |
+| **Google Gemini** | `gemini` | `GOOGLE_API_KEY`, `GEMINI_MODEL` |
 
-See `.env.example` for the full reference.
+Optional shared tuning: `MODEL_MAX_TOKENS` (default: 4096), `MODEL_TEMPERATURE` (default: 0.2).
+
+See `.env.example` for the full reference with per-provider examples.
 
 ---
 

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -75,7 +75,7 @@ Always be concise, accurate, and production-focused.`
 // Config holds the dependencies required to construct a TerraformAgent.
 type Config struct {
 	// ChatModel is the LLM backend constructed by the provider factory.
-	ChatModel model.ChatModel
+	ChatModel model.ToolCallingChatModel
 
 	// Tools is the list of Terraform tools available to the agent.
 	Tools []tool.BaseTool
@@ -114,7 +114,7 @@ func New(ctx context.Context, cfg *Config) (*TerraformAgent, error) {
 	}
 
 	agentCfg := &react.AgentConfig{
-		Model: cfg.ChatModel,
+		ToolCallingModel: cfg.ChatModel,
 		ToolsConfig: compose.ToolsNodeConfig{
 			Tools: cfg.Tools,
 		},

--- a/internal/provider/backends.go
+++ b/internal/provider/backends.go
@@ -12,88 +12,67 @@ import (
 	"google.golang.org/genai"
 )
 
-// newOllama constructs a ChatModel backed by a local Ollama instance.
-// Requires MODEL_BASE_URL (default: http://localhost:11434) and MODEL_NAME.
-func newOllama(ctx context.Context, cfg *Config) (model.ChatModel, error) { //nolint:staticcheck // SA1019: model.ChatModel deprecated upstream; migration tracked separately
-	baseURL := cfg.BaseURL
-	if baseURL == "" {
-		baseURL = "http://localhost:11434"
-	}
+// newOllama constructs a ToolCallingChatModel backed by a local Ollama instance.
+// Reads OLLAMA_HOST (default: http://localhost:11434) and OLLAMA_MODEL.
+func newOllama(ctx context.Context, cfg *Config) (model.ToolCallingChatModel, error) {
 	v, err := einoollama.NewChatModel(ctx, &einoollama.ChatModelConfig{ //nolint:wrapcheck // constructor passthrough
-		BaseURL: baseURL,
-		Model:   cfg.Model,
+		BaseURL: cfg.Ollama.Host,
+		Model:   cfg.Ollama.Model,
 	})
 	return v, err
 }
 
-// newOpenAI constructs a ChatModel backed by the OpenAI API.
-// Requires MODEL_API_KEY and MODEL_NAME.
-func newOpenAI(ctx context.Context, cfg *Config) (model.ChatModel, error) { //nolint:staticcheck // SA1019: model.ChatModel deprecated upstream; migration tracked separately
-	if cfg.APIKey == "" {
-		return nil, fmt.Errorf("provider: MODEL_API_KEY is required for openai backend")
-	}
+// newOpenAI constructs a ToolCallingChatModel backed by the OpenAI API.
+// Reads OPENAI_API_KEY and OPENAI_MODEL.
+func newOpenAI(ctx context.Context, cfg *Config) (model.ToolCallingChatModel, error) {
 	v, err := einoopenai.NewChatModel(ctx, &einoopenai.ChatModelConfig{ //nolint:wrapcheck // constructor passthrough
-		Model:       cfg.Model,
-		APIKey:      cfg.APIKey,
-		MaxTokens:   &cfg.MaxTokens,
-		Temperature: &cfg.Temperature,
+		Model:       cfg.OpenAI.Model,
+		APIKey:      cfg.OpenAI.APIKey,
+		MaxTokens:   &cfg.Tuning.MaxTokens,
+		Temperature: &cfg.Tuning.Temperature,
 	})
 	return v, err
 }
 
-// newAzure constructs a ChatModel backed by Azure OpenAI Service.
-// Requires MODEL_API_KEY, MODEL_BASE_URL (endpoint), and AZURE_DEPLOYMENT.
-func newAzure(ctx context.Context, cfg *Config) (model.ChatModel, error) { //nolint:staticcheck // SA1019: model.ChatModel deprecated upstream; migration tracked separately
-	if cfg.APIKey == "" {
-		return nil, fmt.Errorf("provider: MODEL_API_KEY is required for azure backend")
-	}
-	if cfg.BaseURL == "" {
-		return nil, fmt.Errorf("provider: MODEL_BASE_URL (Azure endpoint) is required for azure backend")
-	}
-	if cfg.AzureDeployment == "" {
-		return nil, fmt.Errorf("provider: AZURE_DEPLOYMENT is required for azure backend")
-	}
+// newAzure constructs a ToolCallingChatModel backed by Azure OpenAI Service.
+// Reads AZURE_OPENAI_API_KEY, AZURE_OPENAI_ENDPOINT, and AZURE_OPENAI_DEPLOYMENT.
+func newAzure(ctx context.Context, cfg *Config) (model.ToolCallingChatModel, error) {
 	return einoopenai.NewChatModel(ctx, &einoopenai.ChatModelConfig{ //nolint:wrapcheck // constructor passthrough
-		Model:       cfg.AzureDeployment,
-		APIKey:      cfg.APIKey,
-		BaseURL:     cfg.BaseURL,
+		Model:       cfg.AzureOpenAI.Deployment,
+		APIKey:      cfg.AzureOpenAI.APIKey,
+		BaseURL:     cfg.AzureOpenAI.Endpoint,
 		ByAzure:     true,
-		APIVersion:  cfg.AzureAPIVersion,
-		MaxTokens:   &cfg.MaxTokens,
-		Temperature: &cfg.Temperature,
+		APIVersion:  cfg.AzureOpenAI.APIVersion,
+		MaxTokens:   &cfg.Tuning.MaxTokens,
+		Temperature: &cfg.Tuning.Temperature,
 		// Use the deployment name as-is — the default mapper strips dots/colons
 		// which breaks deployment names like "gpt-4.1".
 		AzureModelMapperFunc: func(model string) string { return model },
 	})
 }
 
-// newBedrock constructs a ChatModel backed by AWS Bedrock.
+// newBedrock constructs a ToolCallingChatModel backed by AWS Bedrock.
 // AWS credentials are resolved via the standard SDK credential chain
-// (env vars, ~/.aws/credentials, instance profile, etc.).
-// Requires MODEL_NAME (Bedrock model ID) and AWS_REGION.
-func newBedrock(ctx context.Context, cfg *Config) (model.ChatModel, error) { //nolint:staticcheck // SA1019: model.ChatModel deprecated upstream; migration tracked separately
+// (AWS_PROFILE, env vars, ~/.aws/credentials, instance profile, etc.).
+// Reads BEDROCK_MODEL_ID and AWS_REGION.
+func newBedrock(ctx context.Context, cfg *Config) (model.ToolCallingChatModel, error) {
 	// Ark is the ByteDance/Volcano Engine model runtime; for AWS Bedrock we use
 	// the ark provider configured with the Bedrock-compatible endpoint.
 	// TODO: Replace with a dedicated Bedrock implementation when available in eino-ext.
-	maxTokens := cfg.MaxTokens
-	temp := cfg.Temperature
+	maxTokens := cfg.Tuning.MaxTokens
+	temp := cfg.Tuning.Temperature
 	return einoark.NewChatModel(ctx, &einoark.ChatModelConfig{ //nolint:wrapcheck // constructor passthrough
-		Model:       cfg.Model,
-		APIKey:      cfg.APIKey,
-		BaseURL:     cfg.BaseURL,
+		Model:       cfg.Bedrock.ModelID,
 		MaxTokens:   &maxTokens,
 		Temperature: &temp,
 	})
 }
 
-// newGemini constructs a ChatModel backed by Google Gemini (AI Studio or Vertex AI).
-// Requires MODEL_API_KEY and MODEL_NAME (e.g. "gemini-1.5-pro").
-func newGemini(ctx context.Context, cfg *Config) (model.ChatModel, error) { //nolint:staticcheck // SA1019: model.ChatModel deprecated upstream; migration tracked separately
-	if cfg.APIKey == "" {
-		return nil, fmt.Errorf("provider: MODEL_API_KEY is required for gemini backend")
-	}
+// newGemini constructs a ToolCallingChatModel backed by Google Gemini (AI Studio or Vertex AI).
+// Reads GOOGLE_API_KEY and GEMINI_MODEL (e.g. "gemini-1.5-pro").
+func newGemini(ctx context.Context, cfg *Config) (model.ToolCallingChatModel, error) {
 	client, err := genai.NewClient(ctx, &genai.ClientConfig{
-		APIKey:  cfg.APIKey,
+		APIKey:  cfg.Gemini.APIKey,
 		Backend: genai.BackendGeminiAPI,
 	})
 	if err != nil {
@@ -101,6 +80,6 @@ func newGemini(ctx context.Context, cfg *Config) (model.ChatModel, error) { //no
 	}
 	return einogemini.NewChatModel(ctx, &einogemini.Config{ //nolint:wrapcheck // constructor passthrough
 		Client: client,
-		Model:  cfg.Model,
+		Model:  cfg.Gemini.Model,
 	})
 }

--- a/internal/provider/config_test.go
+++ b/internal/provider/config_test.go
@@ -1,0 +1,160 @@
+package provider
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestConfigValidate(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		cfg     Config
+		wantErr string
+	}{
+		// ── Ollama ────────────────────────────────────────────────────────────
+		{
+			name: "ollama/valid",
+			cfg: Config{
+				Backend: BackendOllama,
+				Ollama:  ProviderOllama{Host: "http://localhost:11434", Model: "llama3"},
+			},
+		},
+		{
+			name:    "ollama/missing model",
+			cfg:     Config{Backend: BackendOllama, Ollama: ProviderOllama{Host: "http://localhost:11434"}},
+			wantErr: "OLLAMA_MODEL",
+		},
+
+		// ── OpenAI ────────────────────────────────────────────────────────────
+		{
+			name: "openai/valid",
+			cfg: Config{
+				Backend: BackendOpenAI,
+				OpenAI:  ProviderOpenAI{APIKey: "sk-test", Model: "gpt-4o"},
+			},
+		},
+		{
+			name:    "openai/missing api key",
+			cfg:     Config{Backend: BackendOpenAI, OpenAI: ProviderOpenAI{Model: "gpt-4o"}},
+			wantErr: "OPENAI_API_KEY",
+		},
+		{
+			name:    "openai/missing model",
+			cfg:     Config{Backend: BackendOpenAI, OpenAI: ProviderOpenAI{APIKey: "sk-test"}},
+			wantErr: "OPENAI_MODEL",
+		},
+
+		// ── Azure ─────────────────────────────────────────────────────────────
+		{
+			name: "azure/valid",
+			cfg: Config{
+				Backend: BackendAzure,
+				AzureOpenAI: ProviderAzureOpenAI{
+					APIKey:     "key",
+					Endpoint:   "https://my.openai.azure.com",
+					Deployment: "gpt-4o",
+					APIVersion: "2024-02-01",
+				},
+			},
+		},
+		{
+			name: "azure/missing api key",
+			cfg: Config{
+				Backend: BackendAzure,
+				AzureOpenAI: ProviderAzureOpenAI{
+					Endpoint:   "https://my.openai.azure.com",
+					Deployment: "gpt-4o",
+				},
+			},
+			wantErr: "AZURE_OPENAI_API_KEY",
+		},
+		{
+			name: "azure/missing endpoint",
+			cfg: Config{
+				Backend: BackendAzure,
+				AzureOpenAI: ProviderAzureOpenAI{
+					APIKey:     "key",
+					Deployment: "gpt-4o",
+				},
+			},
+			wantErr: "AZURE_OPENAI_ENDPOINT",
+		},
+		{
+			name: "azure/missing deployment",
+			cfg: Config{
+				Backend: BackendAzure,
+				AzureOpenAI: ProviderAzureOpenAI{
+					APIKey:   "key",
+					Endpoint: "https://my.openai.azure.com",
+				},
+			},
+			wantErr: "AZURE_OPENAI_DEPLOYMENT",
+		},
+
+		// ── Bedrock ───────────────────────────────────────────────────────────
+		{
+			name: "bedrock/valid",
+			cfg: Config{
+				Backend: BackendBedrock,
+				Bedrock: ProviderBedrock{AWSRegion: "us-east-1", ModelID: "anthropic.claude-3"},
+			},
+		},
+		{
+			name:    "bedrock/missing model id",
+			cfg:     Config{Backend: BackendBedrock, Bedrock: ProviderBedrock{AWSRegion: "us-east-1"}},
+			wantErr: "BEDROCK_MODEL_ID",
+		},
+		{
+			name:    "bedrock/missing region",
+			cfg:     Config{Backend: BackendBedrock, Bedrock: ProviderBedrock{ModelID: "anthropic.claude-3"}},
+			wantErr: "AWS_REGION",
+		},
+
+		// ── Gemini ────────────────────────────────────────────────────────────
+		{
+			name: "gemini/valid",
+			cfg: Config{
+				Backend: BackendGemini,
+				Gemini:  ProviderGemini{APIKey: "AIza-test", Model: "gemini-1.5-pro"},
+			},
+		},
+		{
+			name:    "gemini/missing api key",
+			cfg:     Config{Backend: BackendGemini, Gemini: ProviderGemini{Model: "gemini-1.5-pro"}},
+			wantErr: "GOOGLE_API_KEY",
+		},
+		{
+			name:    "gemini/missing model",
+			cfg:     Config{Backend: BackendGemini, Gemini: ProviderGemini{APIKey: "AIza-test"}},
+			wantErr: "GEMINI_MODEL",
+		},
+
+		// ── Unknown backend ───────────────────────────────────────────────────
+		{
+			name:    "unknown backend",
+			cfg:     Config{Backend: "unknown"},
+			wantErr: "unknown backend",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			err := tc.cfg.Validate()
+			if tc.wantErr == "" {
+				if err != nil {
+					t.Errorf("Validate() unexpected error: %v", err)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatalf("Validate() expected error containing %q, got nil", tc.wantErr)
+			}
+			if !strings.Contains(err.Error(), tc.wantErr) {
+				t.Errorf("Validate() error = %q, want substring %q", err.Error(), tc.wantErr)
+			}
+		})
+	}
+}

--- a/internal/provider/factory.go
+++ b/internal/provider/factory.go
@@ -10,38 +10,63 @@ import (
 )
 
 // NewFromEnv constructs a ChatModel by reading provider configuration from
-// environment variables. The MODEL_PROVIDER variable selects the backend;
-// remaining variables are provider-specific.
+// environment variables. MODEL_PROVIDER selects the backend; each provider
+// uses its own native credential env vars.
 //
 // Environment variables:
 //
-//	MODEL_PROVIDER      = ollama | openai | azure | bedrock | gemini  (default: ollama)
-//	MODEL_NAME          = model/deployment name
-//	MODEL_BASE_URL      = base URL override (Ollama, Azure)
-//	MODEL_API_KEY       = API key (OpenAI, Azure, Gemini)
-//	AZURE_DEPLOYMENT    = Azure OpenAI deployment name
-//	AWS_REGION          = AWS region for Bedrock
-//	MODEL_MAX_TOKENS    = max tokens (default: 4096)
-//	MODEL_TEMPERATURE   = temperature 0.0–1.0 (default: 0.2)
-func NewFromEnv(ctx context.Context) (model.ChatModel, error) {
+//	MODEL_PROVIDER              = ollama | openai | azure | bedrock | gemini (default: ollama)
+//
+//	Ollama:  OLLAMA_HOST (default: http://localhost:11434), OLLAMA_MODEL (default: llama3)
+//	OpenAI:  OPENAI_API_KEY, OPENAI_MODEL (default: gpt-4o)
+//	Azure:   AZURE_OPENAI_API_KEY, AZURE_OPENAI_ENDPOINT, AZURE_OPENAI_DEPLOYMENT,
+//	         AZURE_OPENAI_API_VERSION (default: 2024-02-01)
+//	Bedrock: AWS credential chain (AWS_PROFILE / AWS_ACCESS_KEY_ID+AWS_SECRET_ACCESS_KEY /
+//	         instance profile), AWS_REGION (default: us-east-1), BEDROCK_MODEL_ID
+//	Gemini:  GOOGLE_API_KEY, GEMINI_MODEL (default: gemini-1.5-pro)
+//
+//	Shared:  MODEL_MAX_TOKENS (default: 4096), MODEL_TEMPERATURE (default: 0.2)
+func NewFromEnv(ctx context.Context) (model.ToolCallingChatModel, error) {
 	cfg := &Config{
-		Backend:         Backend(getEnvOrDefault("MODEL_PROVIDER", string(BackendOllama))),
-		Model:           getEnvOrDefault("MODEL_NAME", "llama3"),
-		BaseURL:         os.Getenv("MODEL_BASE_URL"),
-		APIKey:          os.Getenv("MODEL_API_KEY"),
-		AzureDeployment: os.Getenv("AZURE_DEPLOYMENT"),
-		AzureAPIVersion: getEnvOrDefault("AZURE_OPENAI_API_VERSION", "2024-02-01"),
-		AWSRegion:       getEnvOrDefault("AWS_REGION", "us-east-1"),
-		MaxTokens:       getEnvInt("MODEL_MAX_TOKENS", 4096),
-		Temperature:     getEnvFloat32("MODEL_TEMPERATURE", 0.2),
+		Backend: Backend(getEnvOrDefault("MODEL_PROVIDER", string(BackendOllama))),
+		Ollama: ProviderOllama{
+			Host:  getEnvOrDefault("OLLAMA_HOST", "http://localhost:11434"),
+			Model: getEnvOrDefault("OLLAMA_MODEL", "llama3"),
+		},
+		OpenAI: ProviderOpenAI{
+			APIKey: os.Getenv("OPENAI_API_KEY"),
+			Model:  getEnvOrDefault("OPENAI_MODEL", "gpt-4o"),
+		},
+		AzureOpenAI: ProviderAzureOpenAI{
+			APIKey:     os.Getenv("AZURE_OPENAI_API_KEY"),
+			Endpoint:   os.Getenv("AZURE_OPENAI_ENDPOINT"),
+			Deployment: os.Getenv("AZURE_OPENAI_DEPLOYMENT"),
+			APIVersion: getEnvOrDefault("AZURE_OPENAI_API_VERSION", "2024-02-01"),
+		},
+		Bedrock: ProviderBedrock{
+			AWSRegion: getEnvOrDefault("AWS_REGION", "us-east-1"),
+			ModelID:   os.Getenv("BEDROCK_MODEL_ID"),
+		},
+		Gemini: ProviderGemini{
+			APIKey: os.Getenv("GOOGLE_API_KEY"),
+			Model:  getEnvOrDefault("GEMINI_MODEL", "gemini-1.5-pro"),
+		},
+		Tuning: SharedTuning{
+			MaxTokens:   getEnvInt("MODEL_MAX_TOKENS", 4096),
+			Temperature: getEnvFloat32("MODEL_TEMPERATURE", 0.2),
+		},
 	}
 
 	return New(ctx, cfg)
 }
 
 // New constructs a ChatModel from an explicit Config, delegating to the
-// appropriate backend factory function.
-func New(ctx context.Context, cfg *Config) (model.ChatModel, error) {
+// appropriate backend factory function. It validates the config first so
+// callers get a clear error at startup rather than on the first request.
+func New(ctx context.Context, cfg *Config) (model.ToolCallingChatModel, error) {
+	if err := cfg.Validate(); err != nil {
+		return nil, err
+	}
 	switch cfg.Backend {
 	case BackendOllama:
 		return newOllama(ctx, cfg)

--- a/internal/provider/interface.go
+++ b/internal/provider/interface.go
@@ -5,6 +5,7 @@ package provider
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/cloudwego/eino/components/model"
 )
@@ -26,41 +27,134 @@ const (
 )
 
 // Config holds all provider-level configuration resolved from environment
-// variables or explicit caller-supplied values.
+// variables. Each provider uses its own native credential env vars rather
+// than a homogenised MODEL_API_KEY abstraction.
 type Config struct {
-	// Backend identifies which inference provider to use.
+	// Backend identifies which inference provider to use (MODEL_PROVIDER).
 	Backend Backend
 
-	// Model is the model name or deployment ID to use (e.g. "gpt-4o", "llama3").
+	// Ollama holds config for a locally running Ollama instance.
+	Ollama ProviderOllama
+
+	// OpenAI holds config for the OpenAI API.
+	OpenAI ProviderOpenAI
+
+	// AzureOpenAI holds config for Azure OpenAI Service.
+	AzureOpenAI ProviderAzureOpenAI
+
+	// Bedrock holds config for AWS Bedrock. Credentials are resolved via
+	// the standard AWS SDK credential chain — no key fields needed here.
+	Bedrock ProviderBedrock
+
+	// Gemini holds config for Google Gemini (AI Studio or Vertex AI).
+	Gemini ProviderGemini
+
+	// Tuning holds shared generation parameters applied to all backends.
+	Tuning SharedTuning
+}
+
+// ProviderOllama holds configuration for a locally running Ollama instance.
+type ProviderOllama struct {
+	// Host is the Ollama server base URL (OLLAMA_HOST).
+	Host string
+	// Model is the Ollama model name to use (OLLAMA_MODEL).
 	Model string
+}
 
-	// BaseURL overrides the default API endpoint (required for Ollama and Azure).
-	BaseURL string
-
-	// APIKey is the authentication credential for the selected provider.
-	// For Bedrock this field is unused; AWS credentials are resolved via the SDK chain.
+// ProviderOpenAI holds configuration for the OpenAI API.
+type ProviderOpenAI struct {
+	// APIKey is the OpenAI API key (OPENAI_API_KEY).
 	APIKey string
+	// Model is the OpenAI model ID (OPENAI_MODEL).
+	Model string
+}
 
-	// AzureDeployment is the Azure OpenAI deployment name (Azure only).
-	AzureDeployment string
+// ProviderAzureOpenAI holds configuration for Azure OpenAI Service.
+type ProviderAzureOpenAI struct {
+	// APIKey is the Azure OpenAI API key (AZURE_OPENAI_API_KEY).
+	APIKey string
+	// Endpoint is the Azure OpenAI resource endpoint (AZURE_OPENAI_ENDPOINT).
+	Endpoint string
+	// Deployment is the Azure OpenAI deployment name (AZURE_OPENAI_DEPLOYMENT).
+	Deployment string
+	// APIVersion is the Azure OpenAI REST API version (AZURE_OPENAI_API_VERSION).
+	APIVersion string
+}
 
-	// AzureAPIVersion is the Azure OpenAI REST API version (Azure only).
-	// Populated from AZURE_OPENAI_API_VERSION (e.g. "2024-02-01").
-	AzureAPIVersion string
-
-	// AWSRegion is the AWS region for Bedrock (Bedrock only).
+// ProviderBedrock holds configuration for AWS Bedrock.
+// Credentials are resolved via the standard AWS SDK credential chain.
+type ProviderBedrock struct {
+	// AWSRegion is the AWS region (AWS_REGION).
 	AWSRegion string
+	// ModelID is the Bedrock model ID (BEDROCK_MODEL_ID).
+	ModelID string
+}
 
+// ProviderGemini holds configuration for Google Gemini.
+type ProviderGemini struct {
+	// APIKey is the Google AI Studio API key (GOOGLE_API_KEY).
+	APIKey string
+	// Model is the Gemini model name (GEMINI_MODEL).
+	Model string
+}
+
+// SharedTuning holds generation parameters shared across all backends.
+type SharedTuning struct {
 	// MaxTokens caps the number of tokens the model may generate per response.
 	MaxTokens int
-
 	// Temperature controls response randomness (0.0–1.0).
 	Temperature float32
 }
 
-// Factory is the interface for constructing a ChatModel from a Config.
+// Validate checks that all required fields for the selected backend are
+// populated. It is called by New() before attempting to construct the model,
+// so callers get a clear error at startup rather than on the first request.
+func (c *Config) Validate() error {
+	switch c.Backend {
+	case BackendOllama:
+		if c.Ollama.Model == "" {
+			return fmt.Errorf("provider: %q requires OLLAMA_MODEL to be set", c.Backend)
+		}
+	case BackendOpenAI:
+		if c.OpenAI.APIKey == "" {
+			return fmt.Errorf("provider: %q requires OPENAI_API_KEY to be set", c.Backend)
+		}
+		if c.OpenAI.Model == "" {
+			return fmt.Errorf("provider: %q requires OPENAI_MODEL to be set", c.Backend)
+		}
+	case BackendAzure:
+		if c.AzureOpenAI.APIKey == "" {
+			return fmt.Errorf("provider: %q requires AZURE_OPENAI_API_KEY to be set", c.Backend)
+		}
+		if c.AzureOpenAI.Endpoint == "" {
+			return fmt.Errorf("provider: %q requires AZURE_OPENAI_ENDPOINT to be set", c.Backend)
+		}
+		if c.AzureOpenAI.Deployment == "" {
+			return fmt.Errorf("provider: %q requires AZURE_OPENAI_DEPLOYMENT to be set", c.Backend)
+		}
+	case BackendBedrock:
+		if c.Bedrock.ModelID == "" {
+			return fmt.Errorf("provider: %q requires BEDROCK_MODEL_ID to be set", c.Backend)
+		}
+		if c.Bedrock.AWSRegion == "" {
+			return fmt.Errorf("provider: %q requires AWS_REGION to be set", c.Backend)
+		}
+	case BackendGemini:
+		if c.Gemini.APIKey == "" {
+			return fmt.Errorf("provider: %q requires GOOGLE_API_KEY to be set", c.Backend)
+		}
+		if c.Gemini.Model == "" {
+			return fmt.Errorf("provider: %q requires GEMINI_MODEL to be set", c.Backend)
+		}
+	default:
+		return fmt.Errorf("provider: unknown backend %q — valid values: ollama, openai, azure, bedrock, gemini", c.Backend)
+	}
+	return nil
+}
+
+// Factory is the interface for constructing a ToolCallingChatModel from a Config.
 // Implementations must be safe to call from multiple goroutines.
 type Factory interface {
-	// New constructs and returns a ready-to-use ChatModel for the given config.
-	New(ctx context.Context, cfg *Config) (model.ChatModel, error)
+	// New constructs and returns a ready-to-use ToolCallingChatModel for the given config.
+	New(ctx context.Context, cfg *Config) (model.ToolCallingChatModel, error)
 }


### PR DESCRIPTION
…llingChatModel

Provider config refactor (closes #15):
- Replace homogenised MODEL_API_KEY/MODEL_BASE_URL/MODEL_NAME with native per-provider env vars: OLLAMA_HOST/MODEL, OPENAI_API_KEY/MODEL, AZURE_OPENAI_API_KEY/ENDPOINT/DEPLOYMENT, BEDROCK_MODEL_ID, GOOGLE_API_KEY/GEMINI_MODEL
- Config struct uses nested ProviderOllama/OpenAI/AzureOpenAI/Bedrock/Gemini sub-structs
- Add Config.Validate() — fails fast at startup with clear per-provider error messages
- Add config_test.go — 17 table-driven tests covering all providers, happy + error paths

Deprecation fix:
- Migrate model.ChatModel → model.ToolCallingChatModel throughout provider, agent, react config
- Switch react.AgentConfig.Model → react.AgentConfig.ToolCallingModel (non-deprecated field)
- Remove all //nolint:staticcheck SA1019 directives — no longer needed
- Remove SA1019 suppress rules from .golangci.yml — staticcheck now catches regressions

Docs:
- .env.example: restructured into per-provider blocks with native var names
- README.md: provider table updated to native env vars