### PR TITLE
feat(logging): structured slog + request correlation IDs

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -10,7 +10,7 @@ import (
 	"fmt"
 	"io"
 	"io/fs"
-	"log"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"strings"
@@ -21,6 +21,7 @@ import (
 	"github.com/cloudwego/eino/flow/agent/react"
 	"github.com/cloudwego/eino/schema"
 
+	"github.com/54b3r/tfai-go/internal/logging"
 	"github.com/54b3r/tfai-go/internal/rag"
 )
 
@@ -200,7 +201,7 @@ func (a *TerraformAgent) buildMessages(ctx context.Context, userMessage, workspa
 		docs, err := a.retriever.Retrieve(ctx, userMessage, a.ragTopK)
 		if err != nil {
 			// RAG failure is non-fatal — log and continue without context.
-			log.Printf("agent: RAG retrieval failed (continuing without context): %v", err)
+			logging.FromContext(ctx).Warn("RAG retrieval failed, continuing without context", slog.Any("error", err))
 		} else if len(docs) > 0 {
 			ragContext := buildRAGContext(docs)
 			messages = append(messages, schema.SystemMessage(ragContext))

--- a/internal/logging/logging.go
+++ b/internal/logging/logging.go
@@ -1,0 +1,66 @@
+// Package logging provides a structured logger built on [log/slog].
+// It is configured once at startup via [New] and distributed through
+// context values using [WithLogger] / [FromContext].
+//
+// Environment variables:
+//
+//	LOG_LEVEL  = debug | info | warn | error  (default: info)
+//	LOG_FORMAT = json | text                  (default: json)
+package logging
+
+import (
+	"context"
+	"log/slog"
+	"os"
+	"strings"
+)
+
+// contextKey is an unexported type for context keys in this package.
+type contextKey struct{}
+
+// New constructs a [*slog.Logger] from environment variables.
+// LOG_FORMAT selects the handler (json for production, text for local dev).
+// LOG_LEVEL sets the minimum severity level.
+func New() *slog.Logger {
+	level := parseLevel(os.Getenv("LOG_LEVEL"))
+
+	opts := &slog.HandlerOptions{Level: level}
+
+	var handler slog.Handler
+	if strings.ToLower(os.Getenv("LOG_FORMAT")) == "text" {
+		handler = slog.NewTextHandler(os.Stderr, opts)
+	} else {
+		handler = slog.NewJSONHandler(os.Stderr, opts)
+	}
+
+	return slog.New(handler)
+}
+
+// WithLogger returns a copy of ctx carrying logger.
+func WithLogger(ctx context.Context, logger *slog.Logger) context.Context {
+	return context.WithValue(ctx, contextKey{}, logger)
+}
+
+// FromContext returns the [*slog.Logger] stored in ctx.
+// If no logger is present it returns [slog.Default] so callers never
+// need to nil-check.
+func FromContext(ctx context.Context) *slog.Logger {
+	if l, ok := ctx.Value(contextKey{}).(*slog.Logger); ok && l != nil {
+		return l
+	}
+	return slog.Default()
+}
+
+// parseLevel converts a string to a [slog.Level], defaulting to Info.
+func parseLevel(s string) slog.Level {
+	switch strings.ToLower(s) {
+	case "debug":
+		return slog.LevelDebug
+	case "warn", "warning":
+		return slog.LevelWarn
+	case "error":
+		return slog.LevelError
+	default:
+		return slog.LevelInfo
+	}
+}

--- a/internal/server/middleware.go
+++ b/internal/server/middleware.go
@@ -1,0 +1,65 @@
+package server
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"log/slog"
+	"net/http"
+	"time"
+
+	"github.com/54b3r/tfai-go/internal/logging"
+)
+
+// requestLogger is an [http.Handler] middleware that:
+//  1. Generates a unique request_id for every inbound request.
+//  2. Injects a child [*slog.Logger] carrying that ID into the request context.
+//  3. Logs method, path, status code, and latency on completion.
+func requestLogger(base *slog.Logger, next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		reqID := newRequestID()
+
+		log := base.With(
+			slog.String("request_id", reqID),
+			slog.String("method", r.Method),
+			slog.String("path", r.URL.Path),
+		)
+
+		ctx := logging.WithLogger(r.Context(), log)
+		r = r.WithContext(ctx)
+
+		rw := &responseWriter{ResponseWriter: w, status: http.StatusOK}
+
+		start := time.Now()
+		next.ServeHTTP(rw, r)
+		elapsed := time.Since(start)
+
+		log.Info("request",
+			slog.Int("status", rw.status),
+			slog.Duration("duration", elapsed),
+		)
+	})
+}
+
+// responseWriter wraps [http.ResponseWriter] to capture the status code
+// written by the handler so the middleware can log it.
+type responseWriter struct {
+	http.ResponseWriter
+	// status is the HTTP status code sent to the client.
+	status int
+}
+
+// WriteHeader captures the status code before delegating to the underlying writer.
+func (rw *responseWriter) WriteHeader(code int) {
+	rw.status = code
+	rw.ResponseWriter.WriteHeader(code)
+}
+
+// newRequestID returns a 16-byte cryptographically random hex string.
+// Falls back to a zero-filled ID on the (impossible in practice) error path.
+func newRequestID() string {
+	b := make([]byte, 8)
+	if _, err := rand.Read(b); err != nil {
+		return "0000000000000000"
+	}
+	return hex.EncodeToString(b)
+}

--- a/internal/server/struct.go
+++ b/internal/server/struct.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"log/slog"
 	"net/http"
 	"time"
 
@@ -19,6 +20,9 @@ type Config struct {
 	WriteTimeout time.Duration
 	// ShutdownTimeout is the maximum duration for a graceful shutdown.
 	ShutdownTimeout time.Duration
+	// Logger is the structured logger used by the server and its handlers.
+	// If nil, [logging.New] is used.
+	Logger *slog.Logger
 }
 
 // Server is the HTTP server that wraps the TerraformAgent.
@@ -29,6 +33,8 @@ type Server struct {
 	cfg *Config
 	// httpServer is the underlying net/http server.
 	httpServer *http.Server
+	// log is the structured logger for this server instance.
+	log *slog.Logger
 }
 
 // chatRequest is the JSON body for POST /api/chat.


### PR DESCRIPTION
Closes #14

## Summary
- New `internal/logging` package: `New()` builds `*slog.Logger` from `LOG_LEVEL`/`LOG_FORMAT` env vars (JSON default, text via `LOG_FORMAT=text`)
- `logging.WithLogger`/`FromContext` for context-propagated logger with `slog.Default()` fallback
- `server/middleware.go`: `requestLogger` middleware injects `request_id` (crypto/rand hex), logs method/path/status/duration as structured fields on every request
- `Logger` field added to `server.Config`, `log` field to `Server` struct
- All `log.Printf` call sites replaced with structured `slog` via `logging.FromContext(ctx)`: `serve.go`, `server.go`, `workspace.go`, `agent.go`
- Logger initialised at startup in `serve.go`, propagated via context and `server.Config`

## Gate
`make gate` — PASS (build, vet, lint, test, binary smoke)