### PR TITLE
test(server): HTTP handler coverage — chat, file, health, workspace

### DIFF
--- a/internal/server/chat_test.go
+++ b/internal/server/chat_test.go
@@ -1,0 +1,172 @@
+package server
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// ---------------------------------------------------------------------------
+// Fake querier for chat handler tests
+// ---------------------------------------------------------------------------
+
+// fakeQuerier implements the querier interface for tests.
+// It writes a fixed response to the writer and returns configurable values.
+type fakeQuerier struct {
+	// response is written verbatim to the writer on each Query call.
+	response string
+	// filesWritten is the value returned as the first return value.
+	filesWritten bool
+	// err is returned as the error value.
+	err error
+}
+
+func (f *fakeQuerier) Query(_ context.Context, _, _ string, w io.Writer) (bool, error) {
+	if f.err != nil {
+		return false, f.err
+	}
+	_, _ = fmt.Fprint(w, f.response)
+	return f.filesWritten, nil
+}
+
+// newChatTestServer builds a *Server wired with the given querier fake.
+func newChatTestServer(q querier) *Server {
+	return &Server{
+		querier: q,
+		cfg:     &Config{Port: 8080},
+		log:     slog.Default(),
+	}
+}
+
+// ---------------------------------------------------------------------------
+// POST /api/chat — validation error paths (no agent needed)
+// ---------------------------------------------------------------------------
+
+func TestHandleChat_MissingMessage(t *testing.T) {
+	t.Parallel()
+
+	s := newChatTestServer(nil)
+	req := httptest.NewRequest(http.MethodPost, "/api/chat",
+		strings.NewReader(`{"workspaceDir":"/tmp"}`))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	s.handleChat(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("expected 400, got %d", w.Code)
+	}
+}
+
+func TestHandleChat_InvalidJSON(t *testing.T) {
+	t.Parallel()
+
+	s := newChatTestServer(nil)
+	req := httptest.NewRequest(http.MethodPost, "/api/chat",
+		strings.NewReader(`not-json`))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	s.handleChat(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("expected 400, got %d", w.Code)
+	}
+}
+
+func TestHandleChat_RelativeWorkspaceDir(t *testing.T) {
+	t.Parallel()
+
+	s := newChatTestServer(nil)
+	req := httptest.NewRequest(http.MethodPost, "/api/chat",
+		strings.NewReader(`{"message":"hi","workspaceDir":"relative/path"}`))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	s.handleChat(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("expected 400, got %d", w.Code)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// POST /api/chat — happy path (fake querier, SSE response)
+// ---------------------------------------------------------------------------
+
+// TestHandleChat_Success verifies that a valid request produces an SSE stream
+// with a "done" event. httptest.ResponseRecorder implements http.Flusher so
+// the handler's flusher check passes without a real connection.
+func TestHandleChat_Success(t *testing.T) {
+	t.Parallel()
+
+	q := &fakeQuerier{response: "resource \"aws_s3_bucket\" \"b\" {}"}
+	s := newChatTestServer(q)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/chat",
+		strings.NewReader(`{"message":"generate an S3 bucket"}`))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	s.handleChat(w, req)
+
+	body := w.Body.String()
+
+	if !strings.Contains(body, "event: done") {
+		t.Errorf("expected SSE done event in body, got: %s", body)
+	}
+	if !strings.Contains(body, "[DONE]") {
+		t.Errorf("expected [DONE] sentinel in body, got: %s", body)
+	}
+}
+
+// TestHandleChat_FilesWritten verifies that when the querier reports files
+// were written, the SSE stream includes a "files_written" event.
+func TestHandleChat_FilesWritten(t *testing.T) {
+	t.Parallel()
+
+	q := &fakeQuerier{response: "ok", filesWritten: true}
+	s := newChatTestServer(q)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/chat",
+		strings.NewReader(`{"message":"generate","workspaceDir":"/tmp"}`))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	s.handleChat(w, req)
+
+	body := w.Body.String()
+	if !strings.Contains(body, "event: files_written") {
+		t.Errorf("expected files_written event in body, got: %s", body)
+	}
+}
+
+// TestHandleChat_AgentError verifies that when the querier returns an error,
+// the SSE stream includes an "error" event and the response is still 200
+// (SSE errors are delivered in-band, not via HTTP status).
+func TestHandleChat_AgentError(t *testing.T) {
+	t.Parallel()
+
+	q := &fakeQuerier{err: fmt.Errorf("LLM unavailable")}
+	s := newChatTestServer(q)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/chat",
+		strings.NewReader(`{"message":"generate"}`))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	s.handleChat(w, req)
+
+	body := w.Body.String()
+	if !strings.Contains(body, "event: error") {
+		t.Errorf("expected error event in body, got: %s", body)
+	}
+	if !strings.Contains(body, "LLM unavailable") {
+		t.Errorf("expected error message in body, got: %s", body)
+	}
+}

--- a/internal/server/file_test.go
+++ b/internal/server/file_test.go
@@ -1,0 +1,208 @@
+package server
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// ---------------------------------------------------------------------------
+// GET /api/file — error paths
+// ---------------------------------------------------------------------------
+
+func TestHandleFileRead_MissingPath(t *testing.T) {
+	t.Parallel()
+
+	s := newTestServer()
+	req := httptest.NewRequest(http.MethodGet, "/api/file?workspaceDir=/tmp", nil)
+	w := httptest.NewRecorder()
+
+	s.handleFileRead(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("expected 400, got %d", w.Code)
+	}
+}
+
+func TestHandleFileRead_MissingWorkspaceDir(t *testing.T) {
+	t.Parallel()
+
+	s := newTestServer()
+	req := httptest.NewRequest(http.MethodGet, "/api/file?path=/tmp/foo.tf", nil)
+	w := httptest.NewRecorder()
+
+	s.handleFileRead(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("expected 400, got %d", w.Code)
+	}
+}
+
+func TestHandleFileRead_PathTraversal(t *testing.T) {
+	t.Parallel()
+
+	s := newTestServer()
+	// path escapes workspaceDir — must be rejected with 403
+	req := httptest.NewRequest(http.MethodGet,
+		"/api/file?path=/tmp/outside.tf&workspaceDir=/tmp/workspace", nil)
+	w := httptest.NewRecorder()
+
+	s.handleFileRead(w, req)
+
+	if w.Code != http.StatusForbidden {
+		t.Errorf("expected 403 Forbidden, got %d", w.Code)
+	}
+}
+
+func TestHandleFileRead_NotFound(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	missing := filepath.Join(dir, "missing.tf")
+
+	s := newTestServer()
+	req := httptest.NewRequest(http.MethodGet,
+		"/api/file?path="+missing+"&workspaceDir="+dir, nil)
+	w := httptest.NewRecorder()
+
+	s.handleFileRead(w, req)
+
+	if w.Code != http.StatusNotFound {
+		t.Errorf("expected 404, got %d", w.Code)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// GET /api/file — happy path
+// ---------------------------------------------------------------------------
+
+func TestHandleFileRead_Success(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "main.tf")
+	mustWriteFile(t, path, "# hello terraform")
+
+	s := newTestServer()
+	req := httptest.NewRequest(http.MethodGet,
+		"/api/file?path="+path+"&workspaceDir="+dir, nil)
+	w := httptest.NewRecorder()
+
+	s.handleFileRead(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d — body: %s", w.Code, w.Body.String())
+	}
+
+	var resp fileResponse
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("failed to decode JSON: %v", err)
+	}
+	if resp.Path != path {
+		t.Errorf("Path: expected %q, got %q", path, resp.Path)
+	}
+	if resp.Content != "# hello terraform" {
+		t.Errorf("Content: expected %q, got %q", "# hello terraform", resp.Content)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// PUT /api/file — error paths
+// ---------------------------------------------------------------------------
+
+func TestHandleFileSave_MissingPath(t *testing.T) {
+	t.Parallel()
+
+	s := newTestServer()
+	req := httptest.NewRequest(http.MethodPut, "/api/file",
+		strings.NewReader(`{"workspaceDir":"/tmp","content":"x"}`))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	s.handleFileSave(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("expected 400, got %d", w.Code)
+	}
+}
+
+func TestHandleFileSave_MissingWorkspaceDir(t *testing.T) {
+	t.Parallel()
+
+	s := newTestServer()
+	req := httptest.NewRequest(http.MethodPut, "/api/file",
+		strings.NewReader(`{"path":"/tmp/foo.tf","content":"x"}`))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	s.handleFileSave(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("expected 400, got %d", w.Code)
+	}
+}
+
+func TestHandleFileSave_PathTraversal(t *testing.T) {
+	t.Parallel()
+
+	s := newTestServer()
+	req := httptest.NewRequest(http.MethodPut, "/api/file",
+		strings.NewReader(`{"path":"/etc/passwd","workspaceDir":"/tmp/workspace","content":"x"}`))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	s.handleFileSave(w, req)
+
+	if w.Code != http.StatusForbidden {
+		t.Errorf("expected 403 Forbidden, got %d", w.Code)
+	}
+}
+
+func TestHandleFileSave_InvalidJSON(t *testing.T) {
+	t.Parallel()
+
+	s := newTestServer()
+	req := httptest.NewRequest(http.MethodPut, "/api/file",
+		strings.NewReader(`not-json`))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	s.handleFileSave(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("expected 400, got %d", w.Code)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// PUT /api/file — happy path
+// ---------------------------------------------------------------------------
+
+func TestHandleFileSave_Success(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "main.tf")
+	body := `{"path":"` + path + `","workspaceDir":"` + dir + `","content":"# written by test"}`
+
+	s := newTestServer()
+	req := httptest.NewRequest(http.MethodPut, "/api/file",
+		strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	s.handleFileSave(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d — body: %s", w.Code, w.Body.String())
+	}
+
+	// Verify the file was actually written to disk with the correct content.
+	got := mustReadFile(t, path)
+	if got != "# written by test" {
+		t.Errorf("file content: expected %q, got %q", "# written by test", got)
+	}
+}

--- a/internal/server/health_test.go
+++ b/internal/server/health_test.go
@@ -1,0 +1,36 @@
+package server
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// TestHandleHealth_OK verifies that GET /api/health returns 200 with a JSON
+// body containing {"status":"ok"}.
+func TestHandleHealth_OK(t *testing.T) {
+	t.Parallel()
+
+	s := newTestServer()
+	req := httptest.NewRequest(http.MethodGet, "/api/health", nil)
+	w := httptest.NewRecorder()
+
+	s.handleHealth(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200 OK, got %d — body: %s", w.Code, w.Body.String())
+	}
+
+	if ct := w.Header().Get("Content-Type"); ct != "application/json" {
+		t.Errorf("Content-Type: expected application/json, got %q", ct)
+	}
+
+	var body map[string]string
+	if err := json.NewDecoder(w.Body).Decode(&body); err != nil {
+		t.Fatalf("failed to decode JSON response: %v", err)
+	}
+	if body["status"] != "ok" {
+		t.Errorf("status: expected %q, got %q", "ok", body["status"])
+	}
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -54,7 +54,7 @@ func New(tfAgent *agent.TerraformAgent, cfg *Config) (*Server, error) {
 		cfg.Logger = logging.New()
 	}
 
-	s := &Server{agent: tfAgent, cfg: cfg, log: cfg.Logger}
+	s := &Server{agent: tfAgent, querier: tfAgent, cfg: cfg, log: cfg.Logger}
 
 	mux := http.NewServeMux()
 	mux.HandleFunc("POST /api/chat", s.handleChat)
@@ -163,7 +163,7 @@ func (s *Server) handleChat(w http.ResponseWriter, r *http.Request) {
 	// sseWriter wraps the ResponseWriter to emit SSE-formatted data events.
 	sw := &sseWriter{w: w, flusher: flusher}
 
-	filesWritten, err := s.agent.Query(ctx, req.Message, req.WorkspaceDir, sw)
+	filesWritten, err := s.querier.Query(ctx, req.Message, req.WorkspaceDir, sw)
 	if err != nil {
 		log.Error("chat agent error", slog.Any("error", err))
 		fmt.Fprintf(w, "event: error\ndata: %s\n\n", err.Error())

--- a/internal/server/workspace_test.go
+++ b/internal/server/workspace_test.go
@@ -19,6 +19,7 @@ package server
 
 import (
 	"encoding/json"
+	"log/slog"
 	"net/http"
 	"net/http/httptest" // provides fake request/response — no real network needed
 	"os"
@@ -125,6 +126,7 @@ func newTestServer() *Server {
 	return &Server{
 		agent: nil,
 		cfg:   &Config{},
+		log:   slog.Default(),
 	}
 }
 
@@ -476,4 +478,15 @@ func mustMkdir(t *testing.T, path string) {
 	if err := os.MkdirAll(path, 0o755); err != nil {
 		t.Fatalf("mustMkdir(%q): %v", path, err)
 	}
+}
+
+// mustReadFile reads a file and returns its content as a string,
+// failing the test immediately on error.
+func mustReadFile(t *testing.T, path string) string {
+	t.Helper()
+	b, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("mustReadFile(%q): %v", path, err)
+	}
+	return string(b)
 }


### PR DESCRIPTION
Closes #18

## Summary

### New test files
- **health_test.go**: `GET /api/health` — 200 status + JSON body shape
- **file_test.go**: `GET /api/file` and `PUT /api/file` — missing params, path traversal (403), not found (404), happy path with disk verification
- **chat_test.go**: `POST /api/chat` — invalid JSON, missing message, relative workspaceDir (400), happy path SSE stream, files_written event, agent error event via `fakeQuerier`
- **workspace_test.go**: added `slog.Default()` to `newTestServer`, added `mustReadFile` helper

### Production changes (testability only)
- `struct.go`: extracted `querier` interface so `handleChat` can be tested without a real LLM agent
- `struct.go`: added `querier` field to `Server` struct
- `server.go`: wire `querier = tfAgent` in `New()`, `handleChat` calls `s.querier`

## Smoke test
Verified against running binary before commit:
- Structured text logging emitting with correct fields
- `request_id` middleware firing with unique IDs per request
- `GET /api/health` → `{"status":"ok"}`
- `GET /api/workspace` → correct JSON shape
- Graceful shutdown on SIGTERM

## Gate
`make gate` — PASS (build, vet, lint, test -race, binary smoke)