### PR TITLE
feat(server): deep health/readiness probes — LLM + Qdrant

### DIFF
--- a/cmd/tfai/commands/serve.go
+++ b/cmd/tfai/commands/serve.go
@@ -78,10 +78,13 @@ Examples:
 				return fmt.Errorf("serve: failed to initialise agent: %w", err)
 			}
 
+			pingers := buildPingers(ctx, chatModel, log)
+
 			srv, err := server.New(tfAgent, &server.Config{
-				Host:   host,
-				Port:   port,
-				Logger: log,
+				Host:    host,
+				Port:    port,
+				Logger:  log,
+				Pingers: pingers,
 			})
 			if err != nil {
 				return fmt.Errorf("serve: failed to create server: %w", err)

--- a/internal/rag/qdrant.go
+++ b/internal/rag/qdrant.go
@@ -182,6 +182,16 @@ func (s *QdrantStore) Delete(ctx context.Context, ids []string) error {
 	return nil
 }
 
+// Ping calls the Qdrant HealthCheck RPC to verify the instance is reachable.
+// Returns nil on success, a descriptive error otherwise.
+func (s *QdrantStore) Ping(ctx context.Context) error {
+	_, err := s.client.HealthCheck(ctx)
+	if err != nil {
+		return fmt.Errorf("qdrant: health check failed: %w", err)
+	}
+	return nil
+}
+
 // Close closes the underlying Qdrant gRPC connection.
 func (s *QdrantStore) Close() error {
 	if err := s.client.Close(); err != nil {

--- a/internal/server/health.go
+++ b/internal/server/health.go
@@ -1,0 +1,116 @@
+package server
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"time"
+
+	"github.com/54b3r/tfai-go/internal/logging"
+)
+
+// probeTimeout is the maximum time allowed for each individual dependency
+// probe during a readiness check. Kept short so /api/ready responds quickly
+// even when a dependency is slow rather than unreachable.
+const probeTimeout = 5 * time.Second
+
+// Pinger is the interface implemented by any dependency that can report its
+// own reachability. Each implementation must return nil when the dependency
+// is healthy and a descriptive error otherwise.
+// Implementations must be safe to call from multiple goroutines.
+type Pinger interface {
+	// Ping checks whether the dependency is reachable within the given context.
+	// Returns nil on success, a descriptive error on failure.
+	Ping(ctx context.Context) error
+
+	// Name returns a short human-readable label used in readiness responses
+	// (e.g. "ollama", "qdrant").
+	Name() string
+}
+
+// MultiPinger aggregates one or more Pinger implementations and reports
+// the combined readiness of all dependencies.
+type MultiPinger struct {
+	// pingers is the ordered list of dependency probes to run.
+	pingers []Pinger
+}
+
+// NewMultiPinger constructs a MultiPinger from the provided list of Pingers.
+func NewMultiPinger(pingers ...Pinger) *MultiPinger {
+	return &MultiPinger{pingers: pingers}
+}
+
+// Ping runs all registered probes sequentially and returns the first error
+// encountered, or nil if all probes succeed.
+func (m *MultiPinger) Ping(ctx context.Context) error {
+	for _, p := range m.pingers {
+		if err := p.Ping(ctx); err != nil {
+			return fmt.Errorf("%s: %w", p.Name(), err)
+		}
+	}
+	return nil
+}
+
+// Name returns a combined label for logging purposes.
+func (m *MultiPinger) Name() string { return "multi" }
+
+// readyCheck holds the per-dependency result of a readiness probe.
+type readyCheck struct {
+	// Name is the dependency label (e.g. "ollama", "qdrant").
+	Name string `json:"name"`
+	// OK is true when the dependency responded successfully.
+	OK bool `json:"ok"`
+	// Error contains the failure reason when OK is false. Empty on success.
+	Error string `json:"error,omitempty"`
+}
+
+// readyResponse is the JSON body returned by GET /api/ready.
+type readyResponse struct {
+	// Ready is true only when every dependency probe succeeded.
+	Ready bool `json:"ready"`
+	// Checks contains the per-dependency probe results.
+	Checks []readyCheck `json:"checks"`
+}
+
+// handleReady handles GET /api/ready for readiness checks.
+// It probes each registered Pinger with a short timeout and returns 200 when
+// all dependencies are reachable, or 503 when any probe fails.
+// Unlike /api/health (liveness), this endpoint reflects actual dependency state.
+func (s *Server) handleReady(w http.ResponseWriter, r *http.Request) {
+	log := logging.FromContext(r.Context())
+
+	resp := readyResponse{Ready: true}
+	allOK := true
+
+	for _, p := range s.pingers {
+		probeCtx, cancel := context.WithTimeout(r.Context(), probeTimeout)
+		err := p.Ping(probeCtx)
+		cancel()
+
+		check := readyCheck{Name: p.Name(), OK: err == nil}
+		if err != nil {
+			check.Error = err.Error()
+			allOK = false
+			log.Warn("readiness probe failed",
+				slog.String("dependency", p.Name()),
+				slog.Any("error", err),
+			)
+		}
+		resp.Checks = append(resp.Checks, check)
+	}
+
+	resp.Ready = allOK
+
+	status := http.StatusOK
+	if !allOK {
+		status = http.StatusServiceUnavailable
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	if err := json.NewEncoder(w).Encode(resp); err != nil {
+		log.Error("ready encode error", slog.Any("error", err))
+	}
+}

--- a/internal/server/health_test.go
+++ b/internal/server/health_test.go
@@ -1,11 +1,39 @@
 package server
 
 import (
+	"context"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"testing"
 )
+
+// ---------------------------------------------------------------------------
+// Fake Pinger for readiness tests
+// ---------------------------------------------------------------------------
+
+// fakePinger is a test double for the Pinger interface.
+type fakePinger struct {
+	// name is returned by Name().
+	name string
+	// err is returned by Ping(); nil means healthy.
+	err error
+}
+
+func (f *fakePinger) Name() string                 { return f.name }
+func (f *fakePinger) Ping(_ context.Context) error { return f.err }
+
+// newReadyTestServer builds a *Server with the given pingers wired in.
+func newReadyTestServer(pingers ...Pinger) *Server {
+	s := newTestServer()
+	s.pingers = pingers
+	return s
+}
+
+// ---------------------------------------------------------------------------
+// GET /api/health — liveness
+// ---------------------------------------------------------------------------
 
 // TestHandleHealth_OK verifies that GET /api/health returns 200 with a JSON
 // body containing {"status":"ok"}.
@@ -32,5 +60,166 @@ func TestHandleHealth_OK(t *testing.T) {
 	}
 	if body["status"] != "ok" {
 		t.Errorf("status: expected %q, got %q", "ok", body["status"])
+	}
+}
+
+// ---------------------------------------------------------------------------
+// GET /api/ready — readiness
+// ---------------------------------------------------------------------------
+
+// TestHandleReady_NoPingers verifies that /api/ready returns 200 with
+// ready:true and an empty checks array when no pingers are registered.
+func TestHandleReady_NoPingers(t *testing.T) {
+	t.Parallel()
+
+	s := newReadyTestServer()
+	req := httptest.NewRequest(http.MethodGet, "/api/ready", nil)
+	w := httptest.NewRecorder()
+
+	s.handleReady(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d — body: %s", w.Code, w.Body.String())
+	}
+
+	var resp readyResponse
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if !resp.Ready {
+		t.Errorf("expected ready:true with no pingers")
+	}
+	if len(resp.Checks) != 0 {
+		t.Errorf("expected 0 checks, got %d", len(resp.Checks))
+	}
+}
+
+// TestHandleReady_AllHealthy verifies that /api/ready returns 200 with
+// ready:true when all pingers succeed.
+func TestHandleReady_AllHealthy(t *testing.T) {
+	t.Parallel()
+
+	s := newReadyTestServer(
+		&fakePinger{name: "llm", err: nil},
+		&fakePinger{name: "qdrant", err: nil},
+	)
+	req := httptest.NewRequest(http.MethodGet, "/api/ready", nil)
+	w := httptest.NewRecorder()
+
+	s.handleReady(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d — body: %s", w.Code, w.Body.String())
+	}
+
+	var resp readyResponse
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if !resp.Ready {
+		t.Errorf("expected ready:true")
+	}
+	if len(resp.Checks) != 2 {
+		t.Fatalf("expected 2 checks, got %d", len(resp.Checks))
+	}
+	for _, c := range resp.Checks {
+		if !c.OK {
+			t.Errorf("check %q: expected ok:true", c.Name)
+		}
+		if c.Error != "" {
+			t.Errorf("check %q: expected no error, got %q", c.Name, c.Error)
+		}
+	}
+}
+
+// TestHandleReady_OneFailing verifies that /api/ready returns 503 with
+// ready:false when one pinger fails, and the failing check has ok:false
+// with a non-empty error field.
+func TestHandleReady_OneFailing(t *testing.T) {
+	t.Parallel()
+
+	s := newReadyTestServer(
+		&fakePinger{name: "llm", err: nil},
+		&fakePinger{name: "qdrant", err: errors.New("connection refused")},
+	)
+	req := httptest.NewRequest(http.MethodGet, "/api/ready", nil)
+	w := httptest.NewRecorder()
+
+	s.handleReady(w, req)
+
+	if w.Code != http.StatusServiceUnavailable {
+		t.Fatalf("expected 503, got %d — body: %s", w.Code, w.Body.String())
+	}
+
+	var resp readyResponse
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if resp.Ready {
+		t.Errorf("expected ready:false")
+	}
+
+	var qdrantCheck *readyCheck
+	for i := range resp.Checks {
+		if resp.Checks[i].Name == "qdrant" {
+			qdrantCheck = &resp.Checks[i]
+		}
+	}
+	if qdrantCheck == nil {
+		t.Fatal("qdrant check missing from response")
+	}
+	if qdrantCheck.OK {
+		t.Errorf("qdrant check: expected ok:false")
+	}
+	if qdrantCheck.Error == "" {
+		t.Errorf("qdrant check: expected non-empty error")
+	}
+}
+
+// TestHandleReady_AllFailing verifies that /api/ready returns 503 with
+// ready:false and all checks showing ok:false when every pinger fails.
+func TestHandleReady_AllFailing(t *testing.T) {
+	t.Parallel()
+
+	s := newReadyTestServer(
+		&fakePinger{name: "llm", err: errors.New("timeout")},
+		&fakePinger{name: "qdrant", err: errors.New("connection refused")},
+	)
+	req := httptest.NewRequest(http.MethodGet, "/api/ready", nil)
+	w := httptest.NewRecorder()
+
+	s.handleReady(w, req)
+
+	if w.Code != http.StatusServiceUnavailable {
+		t.Fatalf("expected 503, got %d — body: %s", w.Code, w.Body.String())
+	}
+
+	var resp readyResponse
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if resp.Ready {
+		t.Errorf("expected ready:false")
+	}
+	for _, c := range resp.Checks {
+		if c.OK {
+			t.Errorf("check %q: expected ok:false", c.Name)
+		}
+	}
+}
+
+// TestHandleReady_ContentType verifies the response always has Content-Type
+// application/json regardless of probe outcome.
+func TestHandleReady_ContentType(t *testing.T) {
+	t.Parallel()
+
+	s := newReadyTestServer(&fakePinger{name: "llm", err: errors.New("down")})
+	req := httptest.NewRequest(http.MethodGet, "/api/ready", nil)
+	w := httptest.NewRecorder()
+
+	s.handleReady(w, req)
+
+	if ct := w.Header().Get("Content-Type"); ct != "application/json" {
+		t.Errorf("Content-Type: expected application/json, got %q", ct)
 	}
 }

--- a/internal/server/pingers.go
+++ b/internal/server/pingers.go
@@ -1,0 +1,69 @@
+package server
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/cloudwego/eino/components/model"
+	"github.com/cloudwego/eino/schema"
+	"github.com/qdrant/go-client/qdrant"
+)
+
+// LLMPinger probes an LLM backend by sending a minimal single-token generate
+// request. It satisfies the Pinger interface and is used by GET /api/ready.
+type LLMPinger struct {
+	// model is the chat model to probe.
+	model model.ToolCallingChatModel
+	// name identifies the backend in readiness responses (e.g. "ollama").
+	name string
+}
+
+// NewLLMPinger constructs an LLMPinger for the given model and backend name.
+func NewLLMPinger(m model.ToolCallingChatModel, name string) *LLMPinger {
+	return &LLMPinger{model: m, name: name}
+}
+
+// Name returns the backend label used in readiness responses.
+func (p *LLMPinger) Name() string { return p.name }
+
+// Ping sends a minimal generate request to the LLM backend.
+// Returns nil if the backend responds, or an error if it is unreachable or
+// returns an unexpected failure. The context deadline controls the timeout.
+func (p *LLMPinger) Ping(ctx context.Context) error {
+	msgs := []*schema.Message{
+		schema.UserMessage("ping"),
+	}
+	resp, err := p.model.Generate(ctx, msgs)
+	if err != nil {
+		return fmt.Errorf("generate failed: %w", err)
+	}
+	if resp == nil {
+		return fmt.Errorf("generate returned nil response")
+	}
+	return nil
+}
+
+// QdrantPinger probes a Qdrant instance using its native HealthCheck RPC.
+// It satisfies the Pinger interface and is used by GET /api/ready.
+type QdrantPinger struct {
+	// client is the Qdrant gRPC client to probe.
+	client *qdrant.Client
+}
+
+// NewQdrantPinger constructs a QdrantPinger for the given Qdrant client.
+func NewQdrantPinger(client *qdrant.Client) *QdrantPinger {
+	return &QdrantPinger{client: client}
+}
+
+// Name returns the dependency label used in readiness responses.
+func (p *QdrantPinger) Name() string { return "qdrant" }
+
+// Ping calls the Qdrant HealthCheck RPC.
+// Returns nil if Qdrant is reachable, or a descriptive error otherwise.
+func (p *QdrantPinger) Ping(ctx context.Context) error {
+	_, err := p.client.HealthCheck(ctx)
+	if err != nil {
+		return fmt.Errorf("health check failed: %w", err)
+	}
+	return nil
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -54,11 +54,18 @@ func New(tfAgent *agent.TerraformAgent, cfg *Config) (*Server, error) {
 		cfg.Logger = logging.New()
 	}
 
-	s := &Server{agent: tfAgent, querier: tfAgent, cfg: cfg, log: cfg.Logger}
+	s := &Server{
+		agent:   tfAgent,
+		querier: tfAgent,
+		cfg:     cfg,
+		log:     cfg.Logger,
+		pingers: cfg.Pingers,
+	}
 
 	mux := http.NewServeMux()
 	mux.HandleFunc("POST /api/chat", s.handleChat)
 	mux.HandleFunc("GET /api/health", s.handleHealth)
+	mux.HandleFunc("GET /api/ready", s.handleReady)
 	mux.HandleFunc("GET /api/workspace", s.handleWorkspace)
 	mux.HandleFunc("POST /api/workspace/create", s.handleWorkspaceCreate)
 	mux.HandleFunc("GET /api/file", s.handleFileRead)

--- a/internal/server/struct.go
+++ b/internal/server/struct.go
@@ -25,6 +25,9 @@ type Config struct {
 	// Logger is the structured logger used by the server and its handlers.
 	// If nil, [logging.New] is used.
 	Logger *slog.Logger
+	// Pingers is the ordered list of dependency probes run by GET /api/ready.
+	// If empty, /api/ready returns 200 with no checks (liveness-only mode).
+	Pingers []Pinger
 }
 
 // querier is the interface handleChat calls to stream a response.
@@ -48,6 +51,8 @@ type Server struct {
 	httpServer *http.Server
 	// log is the structured logger for this server instance.
 	log *slog.Logger
+	// pingers is the ordered list of dependency probes for GET /api/ready.
+	pingers []Pinger
 }
 
 // chatRequest is the JSON body for POST /api/chat.


### PR DESCRIPTION
Closes #16

## Summary

### New endpoints
- **`GET /api/health`** (liveness) — unchanged, always 200 while process is running
- **`GET /api/ready`** (readiness) — probes all registered dependencies, returns 200 or 503

### Readiness response shape
```json
{
  "ready": false,
  "checks": [
    {"name": "ollama", "ok": false, "error": "generate failed: model not found"},
    {"name": "qdrant",  "ok": true}
  ]
}
```

### New files
- `internal/server/health.go` — `Pinger` interface, `MultiPinger`, `handleReady`
- `internal/server/pingers.go` — `LLMPinger` (Generate probe), `QdrantPinger` (HealthCheck RPC)

### Modified
- `internal/server/struct.go` — `Pingers []Pinger` in `Config`, `pingers` field in `Server`
- `internal/server/server.go` — register `GET /api/ready`, wire pingers from config
- `internal/rag/qdrant.go` — add `Ping()` method to `QdrantStore`
- `cmd/tfai/commands/helpers.go` — `buildPingers()`: LLM always included, Qdrant opt-in via `QDRANT_HOST`
- `cmd/tfai/commands/serve.go` — wire `buildPingers` into `server.Config`

## Tests (health_test.go)
- `TestHandleReady_NoPingers` — 200 ready:true, empty checks
- `TestHandleReady_AllHealthy` — 200 ready:true, all checks ok:true
- `TestHandleReady_OneFailing` — 503 ready:false, failing check has error field
- `TestHandleReady_AllFailing` — 503 ready:false, all checks ok:false
- `TestHandleReady_ContentType` — always application/json

## Smoke test
```
GET /api/health → 200 {"status":"ok"}
GET /api/ready  → 503 {"ready":false,"checks":[{"name":"ollama","ok":false,"error":"..."}]}
WARN readiness probe failed dependency=ollama error="model 'llama3' not found"
```
Correct behaviour: Ollama running but model not pulled → 503 with structured log.

## Gate
`make gate` — PASS (build, vet, lint, test -race, binary smoke)