### PR TITLE
feat(server): per-IP token-bucket rate limiting on API routes

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,12 +4,14 @@ go 1.26.0
 
 require (
 	github.com/cloudwego/eino v0.7.13
+	github.com/cloudwego/eino-ext/callbacks/langfuse v0.0.0-20260214075714-8f11ae8e65a2
 	github.com/cloudwego/eino-ext/components/model/ark v0.1.29
 	github.com/cloudwego/eino-ext/components/model/gemini v0.1.7
 	github.com/cloudwego/eino-ext/components/model/ollama v0.1.8
 	github.com/cloudwego/eino-ext/components/model/openai v0.1.8
 	github.com/qdrant/go-client v1.16.2
 	github.com/spf13/cobra v1.10.2
+	golang.org/x/time v0.14.0
 	google.golang.org/genai v1.36.0
 )
 
@@ -24,7 +26,6 @@ require (
 	github.com/bytedance/sonic/loader v0.5.0 // indirect
 	github.com/cenkalti/backoff/v4 v4.3.0 // indirect
 	github.com/cloudwego/base64x v0.1.6 // indirect
-	github.com/cloudwego/eino-ext/callbacks/langfuse v0.0.0-20260214075714-8f11ae8e65a2 // indirect
 	github.com/cloudwego/eino-ext/libs/acl/langfuse v0.0.0-20251124083837-ce2e7e196f9f // indirect
 	github.com/cloudwego/eino-ext/libs/acl/openai v0.1.13 // indirect
 	github.com/dustin/go-humanize v1.0.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -88,6 +88,8 @@ github.com/golang/groupcache v0.0.0-20200121045136-8c9f03a8e57e/go.mod h1:cIg4er
 github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da h1:oI5xCqsCo564l8iNU+DwB5epxmsaqB+rhGL0m5jtYqE=
 github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
 github.com/golang/mock v1.1.1/go.mod h1:oTYuIxOrZwtPieC+H1uAHpcLFnEyAGVDL/k47Jfbm0A=
+github.com/golang/mock v1.6.0 h1:ErTB+efbowRARo13NNdxyJji2egdxLGQhRaY+DUumQc=
+github.com/golang/mock v1.6.0/go.mod h1:p6yTPP+5HYm5mzsMV8JkE6ZKdX+/wYM6Hr+LicevLPs=
 github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.3.2/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.4.0-rc.1/go.mod h1:ceaxUfeHdC40wWswd/P6IGgMaK3YpKi5j83Wpe3EHw8=
@@ -313,6 +315,8 @@ golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
 golang.org/x/text v0.31.0 h1:aC8ghyu4JhP8VojJ2lEHBnochRno1sgL6nEi9WGFGMM=
 golang.org/x/text v0.31.0/go.mod h1:tKRAlv61yKIjGGHX/4tP1LTbc13YSec1pxVEWXzfoeM=
+golang.org/x/time v0.14.0 h1:MRx4UaLrDotUKUdCIqzPC48t1Y9hANFKIRpNx+Te8PI=
+golang.org/x/time v0.14.0/go.mod h1:eL/Oa2bBBK0TkX57Fyni+NgnyQQN4LitPmob2Hjnqw4=
 golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 golang.org/x/tools v0.0.0-20190114222345-bf090417da8b/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 golang.org/x/tools v0.0.0-20190226205152-f727befe758c/go.mod h1:9Yl7xja0Znq3iFh3HoIrodX9oNMXvdceNzlUR8zjMvY=

--- a/internal/server/ratelimit.go
+++ b/internal/server/ratelimit.go
@@ -1,0 +1,141 @@
+package server
+
+import (
+	"log/slog"
+	"net/http"
+	"sync"
+	"time"
+
+	"golang.org/x/time/rate"
+
+	"github.com/54b3r/tfai-go/internal/logging"
+)
+
+// defaultRateLimit is the number of requests per second allowed per IP on
+// rate-limited endpoints when no explicit limit is configured.
+const defaultRateLimit = 10
+
+// defaultRateBurst is the maximum burst size per IP when no explicit burst is
+// configured. A burst of 20 allows short spikes without immediate rejection.
+const defaultRateBurst = 20
+
+// ipLimiter holds a token-bucket rate limiter and the last time it was seen,
+// used to evict stale entries from the limiter map.
+type ipLimiter struct {
+	// limiter is the per-IP token bucket.
+	limiter *rate.Limiter
+	// lastSeen is updated on every request from this IP for LRU eviction.
+	lastSeen time.Time
+}
+
+// rateLimiter is an HTTP middleware that enforces a per-IP token-bucket rate
+// limit. Stale IP entries are evicted every minute to bound memory usage.
+type rateLimiter struct {
+	// mu protects the limiters map.
+	mu sync.Mutex
+	// limiters maps remote IP to its per-IP state.
+	limiters map[string]*ipLimiter
+	// rps is the sustained request rate allowed per IP (requests/second).
+	rps rate.Limit
+	// burst is the maximum instantaneous burst per IP.
+	burst int
+	// log is the structured logger for rate-limit events.
+	log *slog.Logger
+}
+
+// newRateLimiter constructs a rateLimiter and starts the background eviction
+// goroutine. The goroutine exits when the returned stop function is called.
+// rps and burst are the per-IP token-bucket parameters.
+func newRateLimiter(rps float64, burst int, log *slog.Logger) (*rateLimiter, func()) {
+	rl := &rateLimiter{
+		limiters: make(map[string]*ipLimiter),
+		rps:      rate.Limit(rps),
+		burst:    burst,
+		log:      log,
+	}
+
+	stopCh := make(chan struct{})
+	go rl.evictLoop(stopCh)
+
+	return rl, func() { close(stopCh) }
+}
+
+// getLimiter returns the per-IP limiter for the given IP, creating one if
+// it does not already exist.
+func (rl *rateLimiter) getLimiter(ip string) *rate.Limiter {
+	rl.mu.Lock()
+	defer rl.mu.Unlock()
+
+	entry, ok := rl.limiters[ip]
+	if !ok {
+		entry = &ipLimiter{limiter: rate.NewLimiter(rl.rps, rl.burst)}
+		rl.limiters[ip] = entry
+	}
+	entry.lastSeen = time.Now()
+	return entry.limiter
+}
+
+// evictLoop removes IP entries that have not been seen for more than 5 minutes.
+// It runs in a background goroutine and exits when stopCh is closed.
+func (rl *rateLimiter) evictLoop(stopCh <-chan struct{}) {
+	ticker := time.NewTicker(time.Minute)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-stopCh:
+			return
+		case <-ticker.C:
+			rl.evict()
+		}
+	}
+}
+
+// evict removes stale IP entries older than 5 minutes.
+func (rl *rateLimiter) evict() {
+	rl.mu.Lock()
+	defer rl.mu.Unlock()
+
+	cutoff := time.Now().Add(-5 * time.Minute)
+	for ip, entry := range rl.limiters {
+		if entry.lastSeen.Before(cutoff) {
+			delete(rl.limiters, ip)
+		}
+	}
+}
+
+// middleware returns an http.Handler that enforces the rate limit before
+// delegating to next. Requests that exceed the limit receive 429 Too Many
+// Requests with a Retry-After header and a structured WARN log entry.
+func (rl *rateLimiter) middleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		ip := clientIP(r)
+		limiter := rl.getLimiter(ip)
+
+		if !limiter.Allow() {
+			log := logging.FromContext(r.Context())
+			log.Warn("rate limit exceeded",
+				slog.String("ip", ip),
+				slog.String("path", r.URL.Path),
+			)
+			w.Header().Set("Retry-After", "1")
+			http.Error(w, "rate limit exceeded", http.StatusTooManyRequests)
+			return
+		}
+
+		next.ServeHTTP(w, r)
+	})
+}
+
+// clientIP extracts the remote IP from the request, stripping the port.
+// It does not trust X-Forwarded-For since this server is local-only.
+func clientIP(r *http.Request) string {
+	addr := r.RemoteAddr
+	// RemoteAddr is "host:port" for TCP connections.
+	for i := len(addr) - 1; i >= 0; i-- {
+		if addr[i] == ':' {
+			return addr[:i]
+		}
+	}
+	return addr
+}

--- a/internal/server/ratelimit_test.go
+++ b/internal/server/ratelimit_test.go
@@ -1,0 +1,144 @@
+package server
+
+import (
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// okHandler is a trivial handler used to verify that allowed requests reach
+// the downstream handler.
+var okHandler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	w.WriteHeader(http.StatusOK)
+})
+
+// TestRateLimit_AllowsUnderLimit verifies that requests within the burst
+// capacity are passed through to the downstream handler.
+func TestRateLimit_AllowsUnderLimit(t *testing.T) {
+	t.Parallel()
+
+	rl, stop := newRateLimiter(100, 5, slog.Default())
+	defer stop()
+
+	h := rl.middleware(okHandler)
+
+	for i := range 5 {
+		req := httptest.NewRequest(http.MethodGet, "/api/file", nil)
+		req.RemoteAddr = "127.0.0.1:12345"
+		w := httptest.NewRecorder()
+		h.ServeHTTP(w, req)
+		if w.Code != http.StatusOK {
+			t.Errorf("request %d: expected 200, got %d", i, w.Code)
+		}
+	}
+}
+
+// TestRateLimit_BlocksOverLimit verifies that requests exceeding the burst
+// capacity receive 429 Too Many Requests.
+func TestRateLimit_BlocksOverLimit(t *testing.T) {
+	t.Parallel()
+
+	// burst=2, rps=0.001 — third request must be rejected immediately.
+	rl, stop := newRateLimiter(0.001, 2, slog.Default())
+	defer stop()
+
+	h := rl.middleware(okHandler)
+
+	got429 := false
+	for i := range 10 {
+		req := httptest.NewRequest(http.MethodPost, "/api/chat", nil)
+		req.RemoteAddr = "10.0.0.1:9999"
+		w := httptest.NewRecorder()
+		h.ServeHTTP(w, req)
+		if w.Code == http.StatusTooManyRequests {
+			got429 = true
+			_ = i
+			break
+		}
+	}
+	if !got429 {
+		t.Error("expected at least one 429 response, got none")
+	}
+}
+
+// TestRateLimit_RetryAfterHeader verifies that 429 responses include a
+// Retry-After header.
+func TestRateLimit_RetryAfterHeader(t *testing.T) {
+	t.Parallel()
+
+	rl, stop := newRateLimiter(0.001, 1, slog.Default())
+	defer stop()
+
+	h := rl.middleware(okHandler)
+
+	// First request consumes the single burst token.
+	req := httptest.NewRequest(http.MethodPost, "/api/chat", nil)
+	req.RemoteAddr = "10.0.0.2:1234"
+	h.ServeHTTP(httptest.NewRecorder(), req)
+
+	// Second request must be rejected with Retry-After.
+	req2 := httptest.NewRequest(http.MethodPost, "/api/chat", nil)
+	req2.RemoteAddr = "10.0.0.2:1234"
+	w2 := httptest.NewRecorder()
+	h.ServeHTTP(w2, req2)
+
+	if w2.Code != http.StatusTooManyRequests {
+		t.Fatalf("expected 429, got %d", w2.Code)
+	}
+	if w2.Header().Get("Retry-After") == "" {
+		t.Error("expected Retry-After header on 429 response")
+	}
+}
+
+// TestRateLimit_PerIPIsolation verifies that two different IPs have
+// independent token buckets — exhausting one does not affect the other.
+func TestRateLimit_PerIPIsolation(t *testing.T) {
+	t.Parallel()
+
+	rl, stop := newRateLimiter(0.001, 1, slog.Default())
+	defer stop()
+
+	h := rl.middleware(okHandler)
+
+	// Exhaust IP A.
+	for range 5 {
+		req := httptest.NewRequest(http.MethodGet, "/api/file", nil)
+		req.RemoteAddr = "192.168.1.1:1111"
+		h.ServeHTTP(httptest.NewRecorder(), req)
+	}
+
+	// IP B should still be allowed.
+	req := httptest.NewRequest(http.MethodGet, "/api/file", nil)
+	req.RemoteAddr = "192.168.1.2:2222"
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("IP B: expected 200, got %d — should be independent of IP A", w.Code)
+	}
+}
+
+// TestClientIP verifies that clientIP strips the port from RemoteAddr.
+func TestClientIP(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		remoteAddr string
+		wantIP     string
+	}{
+		{"127.0.0.1:54321", "127.0.0.1"},
+		{"10.0.0.1:80", "10.0.0.1"},
+		{"::1:8080", "::1"},
+		{"noport", "noport"},
+	}
+
+	for _, tc := range cases {
+		req := httptest.NewRequest(http.MethodGet, "/", nil)
+		req.RemoteAddr = tc.remoteAddr
+		got := clientIP(req)
+		if got != tc.wantIP {
+			t.Errorf("remoteAddr=%q: expected %q, got %q", tc.remoteAddr, tc.wantIP, got)
+		}
+	}
+}

--- a/internal/server/struct.go
+++ b/internal/server/struct.go
@@ -28,6 +28,11 @@ type Config struct {
 	// Pingers is the ordered list of dependency probes run by GET /api/ready.
 	// If empty, /api/ready returns 200 with no checks (liveness-only mode).
 	Pingers []Pinger
+	// RateLimit is the sustained request rate allowed per IP on rate-limited
+	// endpoints (requests/second). Defaults to 10 if zero.
+	RateLimit float64
+	// RateBurst is the maximum instantaneous burst per IP. Defaults to 20 if zero.
+	RateBurst int
 }
 
 // querier is the interface handleChat calls to stream a response.
@@ -53,6 +58,8 @@ type Server struct {
 	log *slog.Logger
 	// pingers is the ordered list of dependency probes for GET /api/ready.
 	pingers []Pinger
+	// stopRL stops the rate limiter's background eviction goroutine on shutdown.
+	stopRL func()
 }
 
 // chatRequest is the JSON body for POST /api/chat.


### PR DESCRIPTION
Closes #17

## Summary

Rate limiting applied at the **mux level** before handlers, per the SRE rules. Uses `golang.org/x/time/rate` (standard Go token bucket, no external service dependency).

### Rate-limited routes (default: 10 rps sustained, burst 20)
- `POST /api/chat`
- `GET /api/workspace`
- `POST /api/workspace/create`
- `GET /api/file`
- `PUT /api/file`

### Exempt routes
- `GET /api/health` — liveness must always respond regardless of load
- `GET /api/ready` — orchestrator readiness probes must not be throttled

### Behaviour on limit exceeded
- `429 Too Many Requests`
- `Retry-After: 1` header
- Structured `WARN` log with `ip` and `path` fields

## New files
- `internal/server/ratelimit.go` — `rateLimiter`, per-IP `ipLimiter`, `clientIP`, background eviction goroutine (5 min TTL, 1 min tick)
- `internal/server/ratelimit_test.go` — 5 tests

## Modified
- `internal/server/struct.go` — `RateLimit`/`RateBurst` in `Config`, `stopRL` in `Server`
- `internal/server/server.go` — wire `newRateLimiter`, apply middleware, stop eviction on shutdown
- `go.mod` / `go.sum` — add `golang.org/x/time v0.14.0`

## Tests
- `TestRateLimit_AllowsUnderLimit` — burst capacity passes through
- `TestRateLimit_BlocksOverLimit` — 429 after burst exhausted
- `TestRateLimit_RetryAfterHeader` — 429 includes Retry-After
- `TestRateLimit_PerIPIsolation` — exhausting one IP does not affect another
- `TestClientIP` — port stripping from RemoteAddr

## Gate
`make gate` — PASS (build, vet, lint, test -race, binary smoke)