### PR TITLE
feat(system-prompt-v2): Principal Staff Engineer persona, production baseline, self-audit + fix generate path doubling

### DIFF
--- a/cmd/tfai/commands/generate.go
+++ b/cmd/tfai/commands/generate.go
@@ -3,6 +3,7 @@ package commands
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 
 	"github.com/spf13/cobra"
 
@@ -53,6 +54,12 @@ Examples:
 			if err != nil {
 				return fmt.Errorf("generate: failed to initialise agent: %w", err)
 			}
+
+			absOutDir, err := filepath.Abs(outDir)
+			if err != nil {
+				return fmt.Errorf("generate: failed to resolve output directory: %w", err)
+			}
+			outDir = absOutDir
 
 			prompt := fmt.Sprintf(
 				"Generate production-grade Terraform code for the following and write the files to directory %q.\n\n"+

--- a/docs/IMPLEMENTATION_PLAN.md
+++ b/docs/IMPLEMENTATION_PLAN.md
@@ -150,6 +150,31 @@ knowledge of resource schemas, arguments, and best practices.
 
 ---
 
+### Phase 2.5: YAML Config System (Branch: `feat/yaml-config`)
+
+**Goal:** Replace hardcoded prompt profiles, RAG settings, and per-model
+parameters with a YAML config file that can be changed without recompilation.
+
+**Depends on:** Phase 2 (you need enough moving parts to justify the config
+system — prompt profile selection, RAG topK, ingestion sources, per-provider
+model settings)
+
+**Design spec:** See `docs/ROADMAP.md §2.5` for the full SRE-hardened design
+including validate-then-swap, audit logging, config hash, and immutable field
+detection.
+
+#### What Moves Into YAML
+- Prompt profile selection (which profile for which model)
+- RAG topK and chunk size
+- Ingestion source URLs per provider
+- Per-provider model defaults (API version, reasoning detection overrides)
+
+#### What Stays in Env Vars
+- Secrets (API keys, endpoints) — never in config files
+- Runtime flags (port, host) — CLI flags are the right mechanism
+
+---
+
 ### Phase 3: Evaluation Framework (Branch: `feat/eval-framework`)
 
 **Goal:** Structured, repeatable way to measure generate output quality so
@@ -246,6 +271,8 @@ compact models each get optimized instructions.
 Phase 1 (System Prompt v2)
   ↓ commit + PR + merge + tag
 Phase 2 (RAG Pipeline)
+  ↓ commit + PR + merge + tag
+Phase 2.5 (YAML Config System)
   ↓ commit + PR + merge + tag
 Phase 3 (Eval Framework)
   ↓ commit + PR + merge + tag


### PR DESCRIPTION
## Summary

Rewrites the system prompt and fixes a path-doubling bug in `tfai generate`.

## System Prompt v2
- **Persona**: Principal Staff Engineer at the intersection of Platform Engineering, SRE, and Cloud Architecture — unbounded expertise, not role-constrained
- **Non-negotiable standards**: security as baseline, compliance auditor explainability, explicit tradeoff flagging
- **Pre-generation checklist**: encryption, IAM, networking, observability, tagging, lifecycle, provider-specific hardening (IMDSv2, IRSA, managed add-ons)
- **Module design philosophy**: validation blocks, dead variable rule, downstream-useful outputs, purpose comments, section headers, `terraform fmt`-clean HCL
- **Self-audit step**: 7-point checklist the model verifies before responding
- **JSON output contract**: summary must cite key security decisions made

## Bug Fix: generate `--out` path doubling
- Passing a relative `--out` path caused the LLM to echo it back into JSON file paths, resulting in doubled nesting (`test/foo/test/foo/main.tf`)
- Fixed by resolving `--out` to absolute path via `filepath.Abs` before prompt injection and `Query` call

## Regression Test
- `TestApplyFilesNoPathDoubling` — table-driven, covers relative paths, module subdirs, and doubled-path detection

## Validation
- Gate: build ✅ vet ✅ lint ✅ vulncheck ✅ test ✅ smoke ✅
- Manual: v1 vs v2 output comparison — tagging, explicit SGs, correct Atmos paths, better log coverage, node_role_arn output all improved