### PR TITLE
feat(embedder): fail-fast config validation when QDRANT_HOST is set

### DIFF
--- a/cmd/tfai/commands/ask.go
+++ b/cmd/tfai/commands/ask.go
@@ -47,7 +47,10 @@ Examples:
 
 			agentTools := buildTools(runner)
 
-			retriever, closeRetriever := buildRetriever(ctx, slog.Default())
+			retriever, closeRetriever, err := buildRetriever(ctx, slog.Default())
+			if err != nil {
+				return fmt.Errorf("ask: %w", err)
+			}
 			defer closeRetriever()
 
 			tfAgent, err := agent.New(ctx, &agent.Config{

--- a/cmd/tfai/commands/generate.go
+++ b/cmd/tfai/commands/generate.go
@@ -48,7 +48,10 @@ Examples:
 
 			agentTools := buildTools(runner)
 
-			retriever, closeRetriever := buildRetriever(ctx, slog.Default())
+			retriever, closeRetriever, err := buildRetriever(ctx, slog.Default())
+			if err != nil {
+				return fmt.Errorf("generate: %w", err)
+			}
 			defer closeRetriever()
 
 			tfAgent, err := agent.New(ctx, &agent.Config{

--- a/cmd/tfai/commands/serve.go
+++ b/cmd/tfai/commands/serve.go
@@ -97,7 +97,10 @@ Examples:
 				log.Info("history: disabled via TFAI_HISTORY_DB=disabled")
 			}
 
-			retriever, closeRetriever := buildRetriever(ctx, log)
+			retriever, closeRetriever, err := buildRetriever(ctx, log)
+			if err != nil {
+				return fmt.Errorf("serve: %w", err)
+			}
 			defer closeRetriever()
 
 			tfAgent, err := agent.New(ctx, &agent.Config{

--- a/internal/embedder/validate.go
+++ b/internal/embedder/validate.go
@@ -1,0 +1,127 @@
+package embedder
+
+import (
+	"fmt"
+	"log/slog"
+	"os"
+	"strings"
+)
+
+// knownChatModelPrefixes contains name fragments that identify chat/completion
+// models which are NOT suitable for embedding. If EMBEDDING_MODEL matches any
+// of these, a warning is emitted so the operator knows they may have
+// misconfigured the pipeline.
+var knownChatModelPrefixes = []string{
+	"gpt-4",
+	"gpt-3.5",
+	"gpt-35",
+	"o1",
+	"o3",
+	"llama3",
+	"llama2",
+	"llama-3",
+	"llama-2",
+	"mistral",
+	"mixtral",
+	"gemma",
+	"phi-",
+	"phi3",
+	"claude",
+	"command-r",
+	"deepseek",
+	"qwen",
+	"solar",
+	"vicuna",
+	"falcon",
+	"yi-",
+}
+
+// looksLikeChatModel returns true when the model name resembles a known
+// chat/completion model rather than a dedicated embedding model.
+func looksLikeChatModel(model string) bool {
+	lower := strings.ToLower(model)
+	for _, prefix := range knownChatModelPrefixes {
+		if strings.Contains(lower, prefix) {
+			return true
+		}
+	}
+	return false
+}
+
+// ValidateForRAG checks that the embedder configuration is safe to use when
+// QDRANT_HOST is set. It returns an error if the configuration is clearly
+// broken (e.g. azure embedder with no API key), and logs a warning if
+// EMBEDDING_MODEL looks like a chat model rather than an embedding model.
+//
+// This is a pre-flight check — call it before constructing the embedder or
+// the Qdrant store so operators get a clear error at startup rather than a
+// cryptic failure during the first embed call.
+func ValidateForRAG(log *slog.Logger) error {
+	qdrantHost := os.Getenv("QDRANT_HOST")
+	if qdrantHost == "" {
+		// RAG not configured — nothing to validate.
+		return nil
+	}
+
+	// Resolve the effective embedding backend.
+	backend := os.Getenv("EMBEDDING_PROVIDER")
+	if backend == "" {
+		backend = getEnvOrDefault("MODEL_PROVIDER", "ollama")
+	}
+
+	// Warn if the resolved backend is a chat provider with no explicit
+	// EMBEDDING_PROVIDER override — the user may have forgotten to set it.
+	if backend != "ollama" && os.Getenv("EMBEDDING_PROVIDER") == "" {
+		log.Warn("embedder: QDRANT_HOST is set but EMBEDDING_PROVIDER is not — "+
+			"inheriting MODEL_PROVIDER as embedding backend",
+			slog.String("backend", backend),
+			slog.String("hint", "set EMBEDDING_PROVIDER=ollama (or openai/azure) to be explicit"),
+		)
+	}
+
+	// Validate backend-specific required config.
+	switch backend {
+	case "openai":
+		apiKey := os.Getenv("EMBEDDING_API_KEY")
+		if apiKey == "" {
+			apiKey = os.Getenv("OPENAI_API_KEY")
+		}
+		if apiKey == "" {
+			return fmt.Errorf("embedder: QDRANT_HOST is set but no OpenAI API key found — set OPENAI_API_KEY or EMBEDDING_API_KEY")
+		}
+
+	case "azure":
+		apiKey := os.Getenv("EMBEDDING_API_KEY")
+		if apiKey == "" {
+			apiKey = os.Getenv("AZURE_OPENAI_API_KEY")
+		}
+		if apiKey == "" {
+			return fmt.Errorf("embedder: QDRANT_HOST is set but no Azure API key found — set AZURE_OPENAI_API_KEY or EMBEDDING_API_KEY")
+		}
+		endpoint := os.Getenv("EMBEDDING_ENDPOINT")
+		if endpoint == "" {
+			endpoint = os.Getenv("AZURE_OPENAI_ENDPOINT")
+		}
+		if endpoint == "" {
+			return fmt.Errorf("embedder: QDRANT_HOST is set but no Azure endpoint found — set AZURE_OPENAI_ENDPOINT or EMBEDDING_ENDPOINT")
+		}
+
+	case "bedrock":
+		return fmt.Errorf("embedder: QDRANT_HOST is set but bedrock embedding is not yet implemented — set EMBEDDING_PROVIDER to ollama, openai, or azure")
+
+	case "gemini":
+		return fmt.Errorf("embedder: QDRANT_HOST is set but gemini embedding is not yet implemented — set EMBEDDING_PROVIDER to ollama, openai, or azure")
+	}
+
+	// Warn if EMBEDDING_MODEL looks like a chat model.
+	model := os.Getenv("EMBEDDING_MODEL")
+	if model != "" && looksLikeChatModel(model) {
+		log.Warn("embedder: EMBEDDING_MODEL looks like a chat model, not an embedding model — "+
+			"this will likely produce poor or broken embeddings",
+			slog.String("model", model),
+			slog.String("hint", "use a dedicated embedding model e.g. nomic-embed-text, text-embedding-3-small"),
+		)
+	}
+
+	return nil
+}


### PR DESCRIPTION
## Summary

Closes #34 — dedicated embedding model selection (separate from chat model).

When `QDRANT_HOST` is set, the pipeline now validates the embedder configuration eagerly at startup rather than silently degrading to a no-op RAG mode.

## Changes

### `internal/embedder/validate.go` (new)
- `ValidateForRAG(log)` — pre-flight check called before any embedder or Qdrant construction
- Fails fast with a clear error if required credentials are missing (OpenAI API key, Azure endpoint/key)
- Fails fast if an unimplemented backend (bedrock, gemini) is requested with `QDRANT_HOST` set
- Warns if `EMBEDDING_PROVIDER` is not explicitly set (inheriting from `MODEL_PROVIDER`)
- Warns if `EMBEDDING_MODEL` looks like a chat model (llama3, gpt-4, mistral, claude, etc.) rather than a dedicated embedding model

### `cmd/tfai/commands/helpers.go`
- `buildRetriever` now returns `(rag.Retriever, func(), error)` — third value propagates validation and connection errors to callers
- Embedder and Qdrant failures are now hard errors, not silent warn+noop

### `cmd/tfai/commands/serve.go`, `ask.go`, `generate.go`
- Updated to capture the new error return and fail fast with a contextual message

## Behaviour

| Scenario | Before | After |
|---|---|---|
| `QDRANT_HOST` set, azure backend, no API key | Silent noop, RAG disabled | Hard error at startup |
| `QDRANT_HOST` set, `EMBEDDING_MODEL=llama3` | No warning | WARN log with hint |
| `QDRANT_HOST` set, `EMBEDDING_PROVIDER` unset | No warning | WARN log suggesting explicit config |
| `QDRANT_HOST` unset | No change | No change |

## Testing

`make gate` passes: build, vet, lint, vulncheck, tests, binary smoke.