### PR TITLE
feat(ingest): auto-infer metadata from URL patterns, expanded Makefile targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -140,24 +140,45 @@ gate: ## Run full pre-commit gate (build + vet + lint + vulncheck + test + binar
 	@echo "── gate: PASS ───────────────────────────────────────────"
 
 # ── Ingestion ─────────────────────────────────────────────────────────────────
+# Metadata (provider, framework, doc_type) is auto-inferred from the URL.
+# Pass --provider / --framework / --doc-type explicitly only to override.
+
 .PHONY: ingest-aws
 ingest-aws: build ## Ingest core AWS Terraform provider docs into Qdrant
-	./bin/$(BINARY) ingest --provider aws \
+	./bin/$(BINARY) ingest \
 	  --url https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/eks_cluster \
 	  --url https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpc \
-	  --url https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role
+	  --url https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role \
+	  --url https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket \
+	  --url https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lambda_function
 
 .PHONY: ingest-azure
 ingest-azure: build ## Ingest core Azure Terraform provider docs into Qdrant
-	./bin/$(BINARY) ingest --provider azure \
+	./bin/$(BINARY) ingest \
 	  --url https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/kubernetes_cluster \
-	  --url https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/virtual_network
+	  --url https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/virtual_network \
+	  --url https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/storage_account \
+	  --url https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/linux_virtual_machine
 
 .PHONY: ingest-gcp
 ingest-gcp: build ## Ingest core GCP Terraform provider docs into Qdrant
-	./bin/$(BINARY) ingest --provider gcp \
+	./bin/$(BINARY) ingest \
 	  --url https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/container_cluster \
-	  --url https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_network
+	  --url https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_network \
+	  --url https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/storage_bucket \
+	  --url https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/cloudfunctions_function
+
+.PHONY: ingest-atmos
+ingest-atmos: build ## Ingest Atmos framework docs into Qdrant
+	./bin/$(BINARY) ingest \
+	  --url https://atmos.tools/core-concepts/components \
+	  --url https://atmos.tools/core-concepts/stacks \
+	  --url https://atmos.tools/core-concepts/stacks/inheritance \
+	  --url https://atmos.tools/cli/commands/atmos-terraform \
+	  --url https://atmos.tools/quick-start/configure-cli
+
+.PHONY: ingest-all
+ingest-all: ingest-aws ingest-azure ingest-gcp ingest-atmos ## Ingest all provider and framework docs into Qdrant
 # ── fs ───────────────────────────────────────────────────────────────────────
 # Pattern rule: the % is a wildcard stem that matches anything after "fs/".
 # $* expands to the matched stem at recipe time, so "make fs/my-eks-cluster"

--- a/internal/ingestion/metadata.go
+++ b/internal/ingestion/metadata.go
@@ -1,0 +1,160 @@
+package ingestion
+
+import (
+	"net/url"
+	"strings"
+)
+
+// InferredMetadata holds the framework, provider, and doc type inferred from
+// a documentation URL's structure. CLI flags take precedence over inferred
+// values — this is the "best-effort" fallback when the user doesn't specify
+// explicit metadata.
+type InferredMetadata struct {
+	// Framework is the IaC framework (terraform, atmos, terragrunt, cdktf).
+	Framework string
+	// Provider is the cloud provider label (aws, azure, gcp, generic).
+	Provider string
+	// DocType classifies the documentation kind (reference, tutorial, guide, api, changelog).
+	DocType string
+}
+
+// registryProviderAliases maps the Terraform provider namespace used in
+// registry URLs to our canonical short label.
+var registryProviderAliases = map[string]string{
+	"aws":         "aws",
+	"azurerm":     "azure",
+	"azuread":     "azure",
+	"google":      "gcp",
+	"google-beta": "gcp",
+	"kubernetes":  "kubernetes",
+	"helm":        "kubernetes",
+	"random":      "generic",
+	"null":        "generic",
+	"local":       "generic",
+	"tls":         "generic",
+	"archive":     "generic",
+	"template":    "generic",
+	"http":        "generic",
+}
+
+// InferMetadata inspects the documentation source URL and returns best-effort
+// metadata. If the URL doesn't match any known pattern the returned fields
+// contain sensible defaults ("terraform", "generic", "reference").
+//
+// Supported URL patterns:
+//
+//	registry.terraform.io/providers/{org}/{provider}/...
+//	atmos.tools/...
+//	developer.hashicorp.com/terraform/tutorials/...
+//	developer.hashicorp.com/terraform/language/...
+//	terragrunt.gruntwork.io/...
+func InferMetadata(rawURL string) InferredMetadata {
+	m := InferredMetadata{
+		Framework: "terraform",
+		Provider:  "generic",
+		DocType:   "reference",
+	}
+
+	parsed, err := url.Parse(rawURL)
+	if err != nil {
+		return m
+	}
+
+	host := strings.ToLower(parsed.Hostname())
+	path := strings.ToLower(parsed.Path)
+	segments := trimSegments(path)
+
+	switch {
+	case host == "registry.terraform.io":
+		inferRegistryTerraform(segments, &m)
+
+	case host == "atmos.tools":
+		m.Framework = "atmos"
+		m.Provider = "atmos"
+		inferAtmos(segments, &m)
+
+	case host == "developer.hashicorp.com":
+		inferHashiCorpDeveloper(segments, &m)
+
+	case host == "terragrunt.gruntwork.io":
+		m.Framework = "terragrunt"
+		m.DocType = "reference"
+
+	case strings.HasSuffix(host, "cdktf.io") || strings.Contains(path, "cdktf"):
+		m.Framework = "cdktf"
+		m.DocType = "reference"
+	}
+
+	return m
+}
+
+// inferRegistryTerraform handles registry.terraform.io/providers/{org}/{name}/...
+func inferRegistryTerraform(segments []string, m *InferredMetadata) {
+	// Expected path: providers / {org} / {name} / latest / docs / ...
+	if len(segments) < 3 || segments[0] != "providers" {
+		return
+	}
+
+	providerName := segments[2] // e.g. "aws", "azurerm", "google"
+	if alias, ok := registryProviderAliases[providerName]; ok {
+		m.Provider = alias
+	} else {
+		m.Provider = providerName
+	}
+
+	// Detect doc type from deeper path segments.
+	for _, seg := range segments {
+		switch seg {
+		case "guides":
+			m.DocType = "guide"
+			return
+		case "resources", "data-sources":
+			m.DocType = "reference"
+			return
+		}
+	}
+}
+
+// inferAtmos handles atmos.tools/...
+func inferAtmos(segments []string, m *InferredMetadata) {
+	if len(segments) == 0 {
+		return
+	}
+	switch segments[0] {
+	case "quick-start", "getting-started":
+		m.DocType = "tutorial"
+	case "core-concepts", "cli", "design-patterns":
+		m.DocType = "reference"
+	case "integrations":
+		m.DocType = "guide"
+	case "cheatsheets":
+		m.DocType = "reference"
+	}
+}
+
+// inferHashiCorpDeveloper handles developer.hashicorp.com/terraform/...
+func inferHashiCorpDeveloper(segments []string, m *InferredMetadata) {
+	if len(segments) < 2 || segments[0] != "terraform" {
+		return
+	}
+	switch segments[1] {
+	case "tutorials":
+		m.DocType = "tutorial"
+	case "language", "cli", "internals":
+		m.DocType = "reference"
+	case "plugin":
+		m.DocType = "api"
+	}
+}
+
+// trimSegments splits a URL path into non-empty lowercase segments.
+func trimSegments(path string) []string {
+	parts := strings.Split(path, "/")
+	out := make([]string, 0, len(parts))
+	for _, p := range parts {
+		if p != "" {
+			out = append(out, p)
+		}
+	}
+	return out
+}

--- a/internal/ingestion/metadata_test.go
+++ b/internal/ingestion/metadata_test.go
@@ -1,0 +1,188 @@
+package ingestion
+
+import "testing"
+
+func TestInferMetadata(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		url       string
+		framework string
+		provider  string
+		docType   string
+	}{
+		// ── Terraform Registry: AWS ──────────────────────────────────────
+		{
+			name:      "registry aws resource",
+			url:       "https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/eks_cluster",
+			framework: "terraform",
+			provider:  "aws",
+			docType:   "reference",
+		},
+		{
+			name:      "registry aws data source",
+			url:       "https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/vpc",
+			framework: "terraform",
+			provider:  "aws",
+			docType:   "reference",
+		},
+		{
+			name:      "registry aws guide",
+			url:       "https://registry.terraform.io/providers/hashicorp/aws/latest/docs/guides/version-4-upgrade",
+			framework: "terraform",
+			provider:  "aws",
+			docType:   "guide",
+		},
+		// ── Terraform Registry: Azure ────────────────────────────────────
+		{
+			name:      "registry azurerm resource",
+			url:       "https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/kubernetes_cluster",
+			framework: "terraform",
+			provider:  "azure",
+			docType:   "reference",
+		},
+		{
+			name:      "registry azuread resource",
+			url:       "https://registry.terraform.io/providers/hashicorp/azuread/latest/docs/resources/application",
+			framework: "terraform",
+			provider:  "azure",
+			docType:   "reference",
+		},
+		// ── Terraform Registry: GCP ─────────────────────────────────────
+		{
+			name:      "registry google resource",
+			url:       "https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/container_cluster",
+			framework: "terraform",
+			provider:  "gcp",
+			docType:   "reference",
+		},
+		{
+			name:      "registry google-beta resource",
+			url:       "https://registry.terraform.io/providers/hashicorp/google-beta/latest/docs/resources/compute_instance",
+			framework: "terraform",
+			provider:  "gcp",
+			docType:   "reference",
+		},
+		// ── Terraform Registry: other providers ─────────────────────────
+		{
+			name:      "registry kubernetes resource",
+			url:       "https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/deployment",
+			framework: "terraform",
+			provider:  "kubernetes",
+			docType:   "reference",
+		},
+		{
+			name:      "registry unknown provider",
+			url:       "https://registry.terraform.io/providers/someorg/custom/latest/docs/resources/thing",
+			framework: "terraform",
+			provider:  "custom",
+			docType:   "reference",
+		},
+		// ── Atmos ───────────────────────────────────────────────────────
+		{
+			name:      "atmos core concepts",
+			url:       "https://atmos.tools/core-concepts/stacks",
+			framework: "atmos",
+			provider:  "atmos",
+			docType:   "reference",
+		},
+		{
+			name:      "atmos quick start",
+			url:       "https://atmos.tools/quick-start/configure-cli",
+			framework: "atmos",
+			provider:  "atmos",
+			docType:   "tutorial",
+		},
+		{
+			name:      "atmos cli commands",
+			url:       "https://atmos.tools/cli/commands/atmos-terraform",
+			framework: "atmos",
+			provider:  "atmos",
+			docType:   "reference",
+		},
+		{
+			name:      "atmos integrations",
+			url:       "https://atmos.tools/integrations/github-actions",
+			framework: "atmos",
+			provider:  "atmos",
+			docType:   "guide",
+		},
+		// ── HashiCorp Developer ──────────────────────────────────────────
+		{
+			name:      "hashicorp developer tutorial",
+			url:       "https://developer.hashicorp.com/terraform/tutorials/aws-get-started/aws-build",
+			framework: "terraform",
+			provider:  "generic",
+			docType:   "tutorial",
+		},
+		{
+			name:      "hashicorp developer language ref",
+			url:       "https://developer.hashicorp.com/terraform/language/values/variables",
+			framework: "terraform",
+			provider:  "generic",
+			docType:   "reference",
+		},
+		{
+			name:      "hashicorp developer cli ref",
+			url:       "https://developer.hashicorp.com/terraform/cli/commands/plan",
+			framework: "terraform",
+			provider:  "generic",
+			docType:   "reference",
+		},
+		{
+			name:      "hashicorp developer plugin api",
+			url:       "https://developer.hashicorp.com/terraform/plugin/framework",
+			framework: "terraform",
+			provider:  "generic",
+			docType:   "api",
+		},
+		// ── Terragrunt ──────────────────────────────────────────────────
+		{
+			name:      "terragrunt docs",
+			url:       "https://terragrunt.gruntwork.io/docs/features/keep-your-backend-dry/",
+			framework: "terragrunt",
+			provider:  "generic",
+			docType:   "reference",
+		},
+		// ── Fallback / unknown ──────────────────────────────────────────
+		{
+			name:      "completely unknown URL",
+			url:       "https://example.com/some/random/page",
+			framework: "terraform",
+			provider:  "generic",
+			docType:   "reference",
+		},
+		{
+			name:      "malformed URL",
+			url:       "://not-a-url",
+			framework: "terraform",
+			provider:  "generic",
+			docType:   "reference",
+		},
+		{
+			name:      "empty string",
+			url:       "",
+			framework: "terraform",
+			provider:  "generic",
+			docType:   "reference",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := InferMetadata(tt.url)
+
+			if got.Framework != tt.framework {
+				t.Errorf("Framework: got %q, want %q", got.Framework, tt.framework)
+			}
+			if got.Provider != tt.provider {
+				t.Errorf("Provider: got %q, want %q", got.Provider, tt.provider)
+			}
+			if got.DocType != tt.docType {
+				t.Errorf("DocType: got %q, want %q", got.DocType, tt.docType)
+			}
+		})
+	}
+}

--- a/internal/ingestion/pipeline.go
+++ b/internal/ingestion/pipeline.go
@@ -27,6 +27,14 @@ type Source struct {
 
 	// ResourceType is the Terraform resource type this doc covers (e.g. "aws_eks_cluster").
 	ResourceType string
+
+	// Framework is the IaC framework this doc belongs to (e.g. terraform, atmos, terragrunt, cdktf).
+	// Used as a Qdrant payload field to enable framework-scoped retrieval.
+	Framework string
+
+	// DocType classifies the kind of documentation (reference, tutorial, guide, api, changelog).
+	// Used as a Qdrant payload field to enable doc-type-scoped retrieval.
+	DocType string
 }
 
 // Config holds the configuration for the ingestion pipeline.
@@ -136,6 +144,8 @@ func (p *Pipeline) Ingest(ctx context.Context, sources []Source, progress func(m
 				Metadata: map[string]string{
 					"provider":      src.Provider,
 					"resource_type": src.ResourceType,
+					"framework":     src.Framework,
+					"doc_type":      src.DocType,
 					"chunk_index":   fmt.Sprintf("%d", i),
 				},
 			}


### PR DESCRIPTION
## Summary

Adds URL pattern-based metadata auto-inference for the ingestion pipeline, expanded Makefile ingest targets, and structured Qdrant payload fields. Closes the remaining RAG metadata and ingest targets work items.

## Changes

### `internal/ingestion/metadata.go` (new)
- `InferMetadata(url)` — pattern-matches documentation URLs to extract `framework`, `provider`, `doc_type`
- Supports: `registry.terraform.io`, `atmos.tools`, `developer.hashicorp.com`, `terragrunt.gruntwork.io`
- `registryProviderAliases` map: `azurerm`→`azure`, `google`→`gcp`, `kubernetes`→`kubernetes`, etc.
- Unknown URLs default to `terraform/generic/reference`
- Unknown providers used as-is (e.g. `datadog`→`datadog`)

### `internal/ingestion/metadata_test.go` (new)
- 20-case table-driven test suite covering all supported patterns + edge cases (malformed URL, empty string, unknown host)

### `internal/ingestion/pipeline.go`
- Added `Framework` and `DocType` fields to `Source` struct
- Both written to Qdrant payload on every chunk alongside existing `provider`, `resource_type`, `chunk_index`

### `cmd/tfai/commands/ingest.go`
- `--framework` / `--doc-type` CLI flags (defaults: `terraform` / `reference`)
- Uses `cobra.Changed()` to detect explicit flag usage — inferred values fill in when flags are at defaults
- Per-URL log line shows resolved metadata (`source metadata url=... provider=... framework=... doc_type=...`)
- Added `embedder.ValidateForRAG()` pre-flight check

### `Makefile`
- Simplified existing `ingest-aws`, `ingest-azure`, `ingest-gcp` — removed redundant explicit flags (auto-inferred now)
- Added `ingest-atmos` (5 Atmos doc URLs)
- Added `ingest-all` (runs all four)
- Expanded AWS/Azure/GCP targets with additional resource URLs (`s3_bucket`, `lambda_function`, `storage_account`, etc.)

### `README.md`
- New **RAG Ingestion & Metadata** section documenting:
  - Auto-inference behaviour + override semantics
  - Supported URL pattern table
  - Provider alias mapping table
  - How to add a new URL pattern (4-step guide)
  - Future LLM-based classification (`--classify` flag, planned)

## Behaviour

| URL | Inferred provider | Inferred framework | Inferred doc_type |
|---|---|---|---|
| `registry.terraform.io/.../aws/.../resources/...` | `aws` | `terraform` | `reference` |
| `atmos.tools/quick-start/...` | `atmos` | `atmos` | `tutorial` |
| `developer.hashicorp.com/terraform/tutorials/...` | `generic` | `terraform` | `tutorial` |
| `https://example.com/unknown` | `generic` | `terraform` | `reference` |

CLI flags always override: `--provider aws` wins over any inferred value.

## Testing

`make gate` passes: build, vet, lint, vulncheck, tests (including 20-case `TestInferMetadata`), binary smoke.