### PR TITLE
feat: YAML config file support + structured audit logging with key sanitisation

### DIFF
--- a/cmd/tfai/commands/root.go
+++ b/cmd/tfai/commands/root.go
@@ -3,7 +3,17 @@ package commands
 
 import (
 	"github.com/spf13/cobra"
+
+	"github.com/54b3r/tfai-go/internal/audit"
+	"github.com/54b3r/tfai-go/internal/config"
+	"github.com/54b3r/tfai-go/internal/logging"
 )
+
+// configPath holds the --config flag value for YAML config file override.
+var configPath string
+
+// loadedConfigPath stores the resolved config file path for audit logging.
+var loadedConfigPath string
 
 // NewRootCmd constructs the root Cobra command that all subcommands attach to.
 func NewRootCmd() *cobra.Command {
@@ -16,11 +26,29 @@ It can generate Terraform code from natural language, diagnose plan/apply
 failures, advise on state management, and answer infrastructure questions
 across AWS, Azure, and GCP.
 
-Model provider is selected via the MODEL_PROVIDER environment variable.
+Model provider is selected via the MODEL_PROVIDER environment variable
+or a YAML config file (~/.tfai/config.yaml).
 See 'tfai --help' for available commands.`,
 		SilenceUsage:  true,
 		SilenceErrors: true,
+		PersistentPreRunE: func(cmd *cobra.Command, _ []string) error {
+			log := logging.New()
+
+			// Load YAML config (env vars always override YAML values).
+			path, err := config.Load(configPath, log)
+			if err != nil {
+				return err
+			}
+			loadedConfigPath = path
+
+			// Emit structured audit log for every command invocation.
+			audit.LogCommandStart(log, cmd.Name(), loadedConfigPath)
+
+			return nil
+		},
 	}
+
+	root.PersistentFlags().StringVar(&configPath, "config", "", "Path to YAML config file (default: ~/.tfai/config.yaml)")
 
 	root.AddCommand(
 		NewAskCmd(),

--- a/config.yaml.example
+++ b/config.yaml.example
@@ -1,0 +1,67 @@
+# tfai configuration file
+# Copy to ~/.tfai/config.yaml or ./tfai.yaml
+#
+# Precedence: env vars > YAML > built-in defaults
+# Environment variables ALWAYS override YAML values.
+# Secrets (API keys) are best set via env vars, not in this file.
+
+model:
+  # provider: ollama | openai | azure | bedrock | gemini
+  provider: ollama
+  max_tokens: 4096
+  temperature: 0.2
+
+  ollama:
+    host: http://localhost:11434
+    model: llama3
+
+  # openai:
+  #   api_key: ""          # prefer OPENAI_API_KEY env var
+  #   model: gpt-4o
+
+  # azure:
+  #   api_key: ""          # prefer AZURE_OPENAI_API_KEY env var
+  #   endpoint: ""         # prefer AZURE_OPENAI_ENDPOINT env var
+  #   deployment: ""
+  #   api_version: "2025-04-01-preview"
+
+  # bedrock:
+  #   region: us-east-1
+  #   model_id: ""
+
+  # gemini:
+  #   api_key: ""          # prefer GOOGLE_API_KEY env var
+  #   model: gemini-1.5-pro
+
+embedding:
+  # provider: ollama | openai | azure (defaults to model.provider)
+  # provider: ollama
+  # model: nomic-embed-text
+  # dimensions: 768
+  # api_key: ""            # prefer EMBEDDING_API_KEY env var
+  # endpoint: ""           # prefer EMBEDDING_ENDPOINT env var
+
+qdrant:
+  # host: localhost        # set to enable RAG
+  # port: 6334
+  # collection: tfai-docs
+  # api_key: ""            # prefer QDRANT_API_KEY env var
+  # tls: false
+
+server:
+  host: 127.0.0.1
+  port: 8080
+  # api_key: ""            # prefer TFAI_API_KEY env var
+
+logging:
+  level: info              # debug | info | warn | error
+  format: json             # json | text
+
+history:
+  # db_path: ~/.tfai/history.db
+  # db_path: disabled      # set to "disabled" to turn off
+
+# tracing:
+#   public_key: ""         # prefer LANGFUSE_PUBLIC_KEY env var
+#   secret_key: ""         # prefer LANGFUSE_SECRET_KEY env var
+#   host: ""               # prefer LANGFUSE_HOST env var

--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/spf13/cobra v1.10.2
 	golang.org/x/time v0.14.0
 	google.golang.org/genai v1.36.0
+	gopkg.in/yaml.v3 v3.0.1
 	modernc.org/sqlite v1.46.1
 )
 
@@ -93,7 +94,6 @@ require (
 	google.golang.org/grpc v1.76.0 // indirect
 	google.golang.org/protobuf v1.36.10 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
-	gopkg.in/yaml.v3 v3.0.1 // indirect
 	modernc.org/libc v1.67.6 // indirect
 	modernc.org/mathutil v1.7.1 // indirect
 	modernc.org/memory v1.11.0 // indirect

--- a/internal/audit/audit.go
+++ b/internal/audit/audit.go
@@ -1,0 +1,124 @@
+// Package audit provides a structured audit logger for CLI command invocations.
+// It logs command name, resolved configuration, and sanitised environment state
+// so operators can trace what happened without exposing secret values.
+//
+// Secrets are logged as presence/absence only — never their values.
+package audit
+
+import (
+	"context"
+	"log/slog"
+	"os"
+	"strings"
+)
+
+// secretEnvKeys lists environment variable names whose values must never be
+// logged. Only presence ("set") or absence ("unset") is recorded.
+var secretEnvKeys = map[string]bool{
+	"OPENAI_API_KEY":        true,
+	"AZURE_OPENAI_API_KEY":  true,
+	"GOOGLE_API_KEY":        true,
+	"EMBEDDING_API_KEY":     true,
+	"QDRANT_API_KEY":        true,
+	"TFAI_API_KEY":          true,
+	"LANGFUSE_PUBLIC_KEY":   true,
+	"LANGFUSE_SECRET_KEY":   true,
+	"AWS_SECRET_ACCESS_KEY": true,
+	"AWS_SESSION_TOKEN":     true,
+}
+
+// LogCommandStart emits a structured audit log entry when a CLI command begins.
+// It records the command name, config file source, and sanitised environment.
+func LogCommandStart(log *slog.Logger, command string, configPath string) {
+	attrs := []slog.Attr{
+		slog.String("command", command),
+		slog.String("config_file", sanitiseConfigPath(configPath)),
+	}
+
+	// Log key operational env vars with sanitisation.
+	for _, entry := range auditKeys {
+		val := os.Getenv(entry.key)
+		if entry.secret {
+			attrs = append(attrs, slog.String(entry.key, presence(val)))
+		} else {
+			attrs = append(attrs, slog.String(entry.key, valOrUnset(val)))
+		}
+	}
+
+	log.LogAttrs(context.TODO(), slog.LevelInfo, "audit: command start", attrs...)
+}
+
+// auditEntry defines an env var to include in the audit log.
+type auditEntry struct {
+	// key is the environment variable name.
+	key string
+	// secret indicates the value should be redacted to presence/absence.
+	secret bool
+}
+
+// auditKeys is the ordered list of env vars included in every audit log entry.
+var auditKeys = []auditEntry{
+	{"MODEL_PROVIDER", false},
+	{"OLLAMA_HOST", false},
+	{"OLLAMA_MODEL", false},
+	{"OPENAI_API_KEY", true},
+	{"OPENAI_MODEL", false},
+	{"AZURE_OPENAI_API_KEY", true},
+	{"AZURE_OPENAI_ENDPOINT", false},
+	{"AZURE_OPENAI_DEPLOYMENT", false},
+	{"GOOGLE_API_KEY", true},
+	{"GEMINI_MODEL", false},
+	{"AWS_REGION", false},
+	{"BEDROCK_MODEL_ID", false},
+	{"EMBEDDING_PROVIDER", false},
+	{"EMBEDDING_MODEL", false},
+	{"EMBEDDING_API_KEY", true},
+	{"QDRANT_HOST", false},
+	{"QDRANT_PORT", false},
+	{"QDRANT_COLLECTION", false},
+	{"QDRANT_API_KEY", true},
+	{"TFAI_API_KEY", true},
+	{"TFAI_HISTORY_DB", false},
+	{"LOG_LEVEL", false},
+	{"LOG_FORMAT", false},
+	{"LANGFUSE_PUBLIC_KEY", true},
+	{"LANGFUSE_SECRET_KEY", true},
+}
+
+// SanitiseKey returns "set" or "unset" for known secret keys, or the actual
+// value for non-secret keys. This is safe to use in log messages.
+func SanitiseKey(key, value string) string {
+	if secretEnvKeys[key] {
+		return presence(value)
+	}
+	return valOrUnset(value)
+}
+
+// presence returns "set" if the value is non-empty, "unset" otherwise.
+func presence(v string) string {
+	if v != "" {
+		return "set"
+	}
+	return "unset"
+}
+
+// valOrUnset returns the value if non-empty, "unset" otherwise.
+func valOrUnset(v string) string {
+	if v != "" {
+		return v
+	}
+	return "unset"
+}
+
+// sanitiseConfigPath returns the config path or "none" if empty.
+func sanitiseConfigPath(p string) string {
+	if p == "" {
+		return "none"
+	}
+	// Redact home directory for privacy in logs.
+	home, err := os.UserHomeDir()
+	if err == nil && strings.HasPrefix(p, home) {
+		return "~" + p[len(home):]
+	}
+	return p
+}

--- a/internal/audit/audit_test.go
+++ b/internal/audit/audit_test.go
@@ -1,0 +1,53 @@
+package audit
+
+import (
+	"os"
+	"testing"
+)
+
+func TestSanitiseKey_Secret(t *testing.T) {
+	t.Parallel()
+	if got := SanitiseKey("OPENAI_API_KEY", "sk-abc123"); got != "set" {
+		t.Errorf("expected 'set', got %q", got)
+	}
+	if got := SanitiseKey("OPENAI_API_KEY", ""); got != "unset" {
+		t.Errorf("expected 'unset', got %q", got)
+	}
+}
+
+func TestSanitiseKey_NonSecret(t *testing.T) {
+	t.Parallel()
+	if got := SanitiseKey("MODEL_PROVIDER", "azure"); got != "azure" {
+		t.Errorf("expected 'azure', got %q", got)
+	}
+	if got := SanitiseKey("MODEL_PROVIDER", ""); got != "unset" {
+		t.Errorf("expected 'unset', got %q", got)
+	}
+}
+
+func TestPresence(t *testing.T) {
+	t.Parallel()
+	if got := presence("something"); got != "set" {
+		t.Errorf("expected 'set', got %q", got)
+	}
+	if got := presence(""); got != "unset" {
+		t.Errorf("expected 'unset', got %q", got)
+	}
+}
+
+func TestSanitiseConfigPath(t *testing.T) {
+	t.Parallel()
+	if got := sanitiseConfigPath(""); got != "none" {
+		t.Errorf("expected 'none', got %q", got)
+	}
+	if got := sanitiseConfigPath("/tmp/config.yaml"); got != "/tmp/config.yaml" {
+		t.Errorf("expected '/tmp/config.yaml', got %q", got)
+	}
+	home, err := os.UserHomeDir()
+	if err == nil {
+		p := home + "/.tfai/config.yaml"
+		if got := sanitiseConfigPath(p); got != "~/.tfai/config.yaml" {
+			t.Errorf("expected '~/.tfai/config.yaml', got %q", got)
+		}
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,0 +1,314 @@
+// Package config provides YAML-based configuration for tfai.
+// Configuration is loaded with a layered precedence: defaults → YAML file → env vars.
+// Environment variables always win, so existing workflows are unaffected.
+//
+// File search order:
+//  1. --config CLI flag (explicit path)
+//  2. TFAI_CONFIG environment variable
+//  3. ~/.tfai/config.yaml
+//  4. ./tfai.yaml
+//
+// If no file is found the system runs entirely from env vars (backwards compatible).
+package config
+
+import (
+	"fmt"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+// Config is the top-level YAML configuration structure.
+// Field names use yaml tags that mirror the env var naming (lowercase, underscored).
+type Config struct {
+	// Model configures the LLM chat model provider.
+	Model ModelConfig `yaml:"model"`
+
+	// Embedding configures the embedding provider for RAG.
+	Embedding EmbeddingConfig `yaml:"embedding"`
+
+	// Qdrant configures the Qdrant vector store connection.
+	Qdrant QdrantConfig `yaml:"qdrant"`
+
+	// Server configures the HTTP server.
+	Server ServerConfig `yaml:"server"`
+
+	// Logging configures structured logging.
+	Logging LoggingConfig `yaml:"logging"`
+
+	// History configures conversation history persistence.
+	History HistoryConfig `yaml:"history"`
+
+	// Tracing configures Langfuse tracing integration.
+	Tracing TracingConfig `yaml:"tracing"`
+}
+
+// ModelConfig holds LLM chat model settings.
+type ModelConfig struct {
+	// Provider selects the backend: ollama, openai, azure, bedrock, gemini.
+	Provider string `yaml:"provider"`
+
+	// MaxTokens is the maximum number of tokens in the response.
+	MaxTokens int `yaml:"max_tokens"`
+
+	// Temperature controls response randomness (0.0–1.0).
+	Temperature float32 `yaml:"temperature"`
+
+	// Ollama holds Ollama-specific settings.
+	Ollama OllamaConfig `yaml:"ollama"`
+
+	// OpenAI holds OpenAI-specific settings.
+	OpenAI OpenAIConfig `yaml:"openai"`
+
+	// Azure holds Azure OpenAI-specific settings.
+	Azure AzureConfig `yaml:"azure"`
+
+	// Bedrock holds AWS Bedrock-specific settings.
+	Bedrock BedrockConfig `yaml:"bedrock"`
+
+	// Gemini holds Google Gemini-specific settings.
+	Gemini GeminiConfig `yaml:"gemini"`
+}
+
+// OllamaConfig holds Ollama provider settings.
+type OllamaConfig struct {
+	// Host is the Ollama API endpoint.
+	Host string `yaml:"host"`
+	// Model is the Ollama model name.
+	Model string `yaml:"model"`
+}
+
+// OpenAIConfig holds OpenAI provider settings.
+type OpenAIConfig struct {
+	// APIKey is the OpenAI API key. Prefer env var OPENAI_API_KEY.
+	APIKey string `yaml:"api_key"`
+	// Model is the OpenAI model name.
+	Model string `yaml:"model"`
+}
+
+// AzureConfig holds Azure OpenAI provider settings.
+type AzureConfig struct {
+	// APIKey is the Azure OpenAI API key. Prefer env var AZURE_OPENAI_API_KEY.
+	APIKey string `yaml:"api_key"`
+	// Endpoint is the Azure OpenAI resource endpoint.
+	Endpoint string `yaml:"endpoint"`
+	// Deployment is the Azure OpenAI deployment name.
+	Deployment string `yaml:"deployment"`
+	// APIVersion is the Azure OpenAI API version.
+	APIVersion string `yaml:"api_version"`
+}
+
+// BedrockConfig holds AWS Bedrock provider settings.
+type BedrockConfig struct {
+	// Region is the AWS region for Bedrock.
+	Region string `yaml:"region"`
+	// ModelID is the Bedrock model identifier.
+	ModelID string `yaml:"model_id"`
+}
+
+// GeminiConfig holds Google Gemini provider settings.
+type GeminiConfig struct {
+	// APIKey is the Google API key. Prefer env var GOOGLE_API_KEY.
+	APIKey string `yaml:"api_key"`
+	// Model is the Gemini model name.
+	Model string `yaml:"model"`
+}
+
+// EmbeddingConfig holds embedding provider settings for RAG.
+type EmbeddingConfig struct {
+	// Provider selects the embedding backend (ollama, openai, azure).
+	Provider string `yaml:"provider"`
+	// Model is the embedding model name.
+	Model string `yaml:"model"`
+	// Dimensions overrides the embedding vector size.
+	Dimensions int `yaml:"dimensions"`
+	// APIKey is the embedding API key. Prefer env var EMBEDDING_API_KEY.
+	APIKey string `yaml:"api_key"`
+	// Endpoint is the embedding API endpoint.
+	Endpoint string `yaml:"endpoint"`
+}
+
+// QdrantConfig holds Qdrant vector store settings.
+type QdrantConfig struct {
+	// Host is the Qdrant server hostname.
+	Host string `yaml:"host"`
+	// Port is the Qdrant gRPC port.
+	Port int `yaml:"port"`
+	// Collection is the Qdrant collection name.
+	Collection string `yaml:"collection"`
+	// APIKey is the Qdrant API key. Prefer env var QDRANT_API_KEY.
+	APIKey string `yaml:"api_key"`
+	// TLS enables TLS for the Qdrant connection.
+	TLS bool `yaml:"tls"`
+}
+
+// ServerConfig holds HTTP server settings.
+type ServerConfig struct {
+	// Host is the bind address.
+	Host string `yaml:"host"`
+	// Port is the TCP port.
+	Port int `yaml:"port"`
+	// APIKey is the Bearer token for API authentication. Prefer env var TFAI_API_KEY.
+	APIKey string `yaml:"api_key"`
+}
+
+// LoggingConfig holds structured logging settings.
+type LoggingConfig struct {
+	// Level is the minimum log level: debug, info, warn, error.
+	Level string `yaml:"level"`
+	// Format is the log output format: json, text.
+	Format string `yaml:"format"`
+}
+
+// HistoryConfig holds conversation history settings.
+type HistoryConfig struct {
+	// DBPath is the SQLite database path. Set to "disabled" to disable.
+	DBPath string `yaml:"db_path"`
+}
+
+// TracingConfig holds Langfuse tracing settings.
+type TracingConfig struct {
+	// PublicKey is the Langfuse public key. Prefer env var LANGFUSE_PUBLIC_KEY.
+	PublicKey string `yaml:"public_key"`
+	// SecretKey is the Langfuse secret key. Prefer env var LANGFUSE_SECRET_KEY.
+	SecretKey string `yaml:"secret_key"`
+	// Host is the Langfuse API host.
+	Host string `yaml:"host"`
+}
+
+// envMapping maps YAML config fields to their corresponding env var names.
+// Only non-empty YAML values are applied; env vars always take precedence.
+var envMapping = []struct {
+	envKey string
+	value  func(*Config) string
+}{
+	{"MODEL_PROVIDER", func(c *Config) string { return c.Model.Provider }},
+	{"MODEL_MAX_TOKENS", func(c *Config) string { return intStr(c.Model.MaxTokens) }},
+	{"MODEL_TEMPERATURE", func(c *Config) string { return float32Str(c.Model.Temperature) }},
+	{"OLLAMA_HOST", func(c *Config) string { return c.Model.Ollama.Host }},
+	{"OLLAMA_MODEL", func(c *Config) string { return c.Model.Ollama.Model }},
+	{"OPENAI_API_KEY", func(c *Config) string { return c.Model.OpenAI.APIKey }},
+	{"OPENAI_MODEL", func(c *Config) string { return c.Model.OpenAI.Model }},
+	{"AZURE_OPENAI_API_KEY", func(c *Config) string { return c.Model.Azure.APIKey }},
+	{"AZURE_OPENAI_ENDPOINT", func(c *Config) string { return c.Model.Azure.Endpoint }},
+	{"AZURE_OPENAI_DEPLOYMENT", func(c *Config) string { return c.Model.Azure.Deployment }},
+	{"AZURE_OPENAI_API_VERSION", func(c *Config) string { return c.Model.Azure.APIVersion }},
+	{"AWS_REGION", func(c *Config) string { return c.Model.Bedrock.Region }},
+	{"BEDROCK_MODEL_ID", func(c *Config) string { return c.Model.Bedrock.ModelID }},
+	{"GOOGLE_API_KEY", func(c *Config) string { return c.Model.Gemini.APIKey }},
+	{"GEMINI_MODEL", func(c *Config) string { return c.Model.Gemini.Model }},
+	{"EMBEDDING_PROVIDER", func(c *Config) string { return c.Embedding.Provider }},
+	{"EMBEDDING_MODEL", func(c *Config) string { return c.Embedding.Model }},
+	{"EMBEDDING_DIMENSIONS", func(c *Config) string { return intStr(c.Embedding.Dimensions) }},
+	{"EMBEDDING_API_KEY", func(c *Config) string { return c.Embedding.APIKey }},
+	{"EMBEDDING_ENDPOINT", func(c *Config) string { return c.Embedding.Endpoint }},
+	{"QDRANT_HOST", func(c *Config) string { return c.Qdrant.Host }},
+	{"QDRANT_PORT", func(c *Config) string { return intStr(c.Qdrant.Port) }},
+	{"QDRANT_COLLECTION", func(c *Config) string { return c.Qdrant.Collection }},
+	{"QDRANT_API_KEY", func(c *Config) string { return c.Qdrant.APIKey }},
+	{"QDRANT_TLS", func(c *Config) string { return boolStr(c.Qdrant.TLS) }},
+	{"LOG_LEVEL", func(c *Config) string { return c.Logging.Level }},
+	{"LOG_FORMAT", func(c *Config) string { return c.Logging.Format }},
+	{"TFAI_HISTORY_DB", func(c *Config) string { return c.History.DBPath }},
+	{"LANGFUSE_PUBLIC_KEY", func(c *Config) string { return c.Tracing.PublicKey }},
+	{"LANGFUSE_SECRET_KEY", func(c *Config) string { return c.Tracing.SecretKey }},
+	{"LANGFUSE_HOST", func(c *Config) string { return c.Tracing.Host }},
+}
+
+// Load reads a YAML config file and applies non-empty values as environment
+// variables. Existing env vars are never overwritten (env always wins).
+// Returns the path that was loaded, or empty string if no file was found.
+func Load(explicitPath string, log *slog.Logger) (string, error) {
+	path := resolveConfigPath(explicitPath)
+	if path == "" {
+		log.Debug("config: no YAML config file found, using env vars only")
+		return "", nil
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return "", fmt.Errorf("config: failed to read %s: %w", path, err)
+	}
+
+	var cfg Config
+	if err := yaml.Unmarshal(data, &cfg); err != nil {
+		return "", fmt.Errorf("config: failed to parse %s: %w", path, err)
+	}
+
+	applied := 0
+	for _, m := range envMapping {
+		yamlVal := m.value(&cfg)
+		if yamlVal == "" || yamlVal == "0" || yamlVal == "false" {
+			continue
+		}
+		if os.Getenv(m.envKey) != "" {
+			continue // env var already set — do not override
+		}
+		os.Setenv(m.envKey, yamlVal)
+		applied++
+	}
+
+	log.Info("config: loaded YAML config",
+		slog.String("path", path),
+		slog.Int("keys_applied", applied),
+	)
+
+	return path, nil
+}
+
+// resolveConfigPath returns the first config file path that exists.
+func resolveConfigPath(explicit string) string {
+	if explicit != "" {
+		if _, err := os.Stat(explicit); err == nil {
+			return explicit
+		}
+		return ""
+	}
+
+	if envPath := os.Getenv("TFAI_CONFIG"); envPath != "" {
+		if _, err := os.Stat(envPath); err == nil {
+			return envPath
+		}
+	}
+
+	home, err := os.UserHomeDir()
+	if err == nil {
+		p := filepath.Join(home, ".tfai", "config.yaml")
+		if _, err := os.Stat(p); err == nil {
+			return p
+		}
+	}
+
+	if _, err := os.Stat("tfai.yaml"); err == nil {
+		return "tfai.yaml"
+	}
+
+	return ""
+}
+
+// intStr converts an int to string, returning "" for zero values.
+func intStr(v int) string {
+	if v == 0 {
+		return ""
+	}
+	return fmt.Sprintf("%d", v)
+}
+
+// float32Str converts a float32 to string, returning "" for zero values.
+func float32Str(v float32) string {
+	if v == 0 {
+		return ""
+	}
+	return strings.TrimRight(strings.TrimRight(fmt.Sprintf("%.4f", v), "0"), ".")
+}
+
+// boolStr converts a bool to string, returning "" for false.
+func boolStr(v bool) string {
+	if !v {
+		return ""
+	}
+	return "true"
+}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,0 +1,153 @@
+package config
+
+import (
+	"log/slog"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestLoad_NoFile(t *testing.T) {
+	t.Parallel()
+
+	log := slog.Default()
+	path, err := Load("/nonexistent/path/config.yaml", log)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if path != "" {
+		t.Errorf("expected empty path, got %q", path)
+	}
+}
+
+func TestLoad_ValidFile(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "config.yaml")
+
+	content := []byte(`
+model:
+  provider: azure
+  max_tokens: 8192
+  temperature: 0.3
+  azure:
+    endpoint: https://my-resource.openai.azure.com
+    deployment: gpt-4o
+    api_version: "2025-04-01-preview"
+embedding:
+  provider: ollama
+  model: nomic-embed-text
+qdrant:
+  host: qdrant.internal
+  port: 6334
+  collection: my-docs
+logging:
+  level: debug
+  format: text
+`)
+
+	if err := os.WriteFile(cfgPath, content, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Clear env vars that the YAML should set.
+	envKeys := []string{
+		"MODEL_PROVIDER", "MODEL_MAX_TOKENS", "MODEL_TEMPERATURE",
+		"AZURE_OPENAI_ENDPOINT", "AZURE_OPENAI_DEPLOYMENT", "AZURE_OPENAI_API_VERSION",
+		"EMBEDDING_PROVIDER", "EMBEDDING_MODEL",
+		"QDRANT_HOST", "QDRANT_PORT", "QDRANT_COLLECTION",
+		"LOG_LEVEL", "LOG_FORMAT",
+	}
+	for _, k := range envKeys {
+		t.Setenv(k, "")
+		os.Unsetenv(k)
+	}
+
+	log := slog.Default()
+	loaded, err := Load(cfgPath, log)
+	if err != nil {
+		t.Fatalf("Load failed: %v", err)
+	}
+	if loaded != cfgPath {
+		t.Errorf("loaded path: got %q, want %q", loaded, cfgPath)
+	}
+
+	checks := map[string]string{
+		"MODEL_PROVIDER":           "azure",
+		"MODEL_MAX_TOKENS":         "8192",
+		"AZURE_OPENAI_ENDPOINT":    "https://my-resource.openai.azure.com",
+		"AZURE_OPENAI_DEPLOYMENT":  "gpt-4o",
+		"AZURE_OPENAI_API_VERSION": "2025-04-01-preview",
+		"EMBEDDING_PROVIDER":       "ollama",
+		"EMBEDDING_MODEL":          "nomic-embed-text",
+		"QDRANT_HOST":              "qdrant.internal",
+		"QDRANT_PORT":              "6334",
+		"QDRANT_COLLECTION":        "my-docs",
+		"LOG_LEVEL":                "debug",
+		"LOG_FORMAT":               "text",
+	}
+	for k, want := range checks {
+		got := os.Getenv(k)
+		if got != want {
+			t.Errorf("%s: got %q, want %q", k, got, want)
+		}
+	}
+}
+
+func TestLoad_EnvOverridesYAML(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "config.yaml")
+
+	content := []byte(`
+model:
+  provider: ollama
+`)
+	if err := os.WriteFile(cfgPath, content, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Set env var BEFORE loading — it should NOT be overwritten.
+	t.Setenv("MODEL_PROVIDER", "azure")
+
+	log := slog.Default()
+	_, err := Load(cfgPath, log)
+	if err != nil {
+		t.Fatalf("Load failed: %v", err)
+	}
+
+	if got := os.Getenv("MODEL_PROVIDER"); got != "azure" {
+		t.Errorf("MODEL_PROVIDER: expected env override %q, got %q", "azure", got)
+	}
+}
+
+func TestLoad_InvalidYAML(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "config.yaml")
+
+	if err := os.WriteFile(cfgPath, []byte("{{invalid yaml"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	log := slog.Default()
+	_, err := Load(cfgPath, log)
+	if err == nil {
+		t.Fatal("expected error for invalid YAML")
+	}
+}
+
+func TestFloat32Str(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		in   float32
+		want string
+	}{
+		{0.0, ""},
+		{0.2, "0.2"},
+		{0.3, "0.3"},
+		{1.0, "1"},
+	}
+	for _, tt := range tests {
+		if got := float32Str(tt.in); got != tt.want {
+			t.Errorf("float32Str(%v) = %q, want %q", tt.in, got, tt.want)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Adds two features: layered YAML configuration and structured CLI audit logging with secret sanitisation.

## WI-8: YAML Configuration

### New: `internal/config` package
- **Layered precedence**: defaults → YAML file → env vars (env always wins)
- **File search order**: `--config` flag > `TFAI_CONFIG` env > `~/.tfai/config.yaml` > `./tfai.yaml`
- 30+ env var mappings covering: model, embedding, qdrant, server, logging, history, tracing
- Backwards compatible — runs from env vars alone if no YAML file exists

### New: `config.yaml.example`
- Fully annotated reference with all sections and security guidance (secrets via env vars only)

### New: `--config` global flag
- Persistent flag on root command, available to all subcommands

### Tests
- Valid file loading + env var application
- Env var override (env wins over YAML)
- Invalid YAML error handling
- No-file fallback (graceful)
- `float32Str` edge cases

## WI-10: CLI Audit Logging

### New: `internal/audit` package
- **`LogCommandStart()`** — structured slog entry on every CLI command
- **Key sanitisation**: secret env vars logged as `"set"`/`"unset"` only
- Non-secret config logged in full for operational visibility
- Home directory redacted in config file path (`~/.tfai/...`)
- Sanitised keys: `OPENAI_API_KEY`, `AZURE_OPENAI_API_KEY`, `GOOGLE_API_KEY`, `EMBEDDING_API_KEY`, `QDRANT_API_KEY`, `TFAI_API_KEY`, `LANGFUSE_*_KEY`, `AWS_SECRET_ACCESS_KEY`, `AWS_SESSION_TOKEN`

### Tests
- Secret key sanitisation (`set`/`unset`)
- Non-secret key passthrough
- Config path redaction
- Presence helper

### Wiring
- Both features wired via `PersistentPreRunE` on root command — runs before every subcommand
- Config loads first (sets env vars from YAML), then audit logs the resolved state

## Example audit output

```json
{
  "level": "INFO",
  "msg": "audit: command start",
  "command": "version",
  "config_file": "none",
  "MODEL_PROVIDER": "azure",
  "AZURE_OPENAI_API_KEY": "set",
  "AZURE_OPENAI_ENDPOINT": "https://my-resource.openai.azure.com/",
  "QDRANT_HOST": "localhost",
  "LANGFUSE_PUBLIC_KEY": "set"
}
```

## README updates
- New **YAML Configuration** section (search order, example, security note)
- New **Audit Logging** section (example output, sanitisation explanation)
- Architecture tree updated with `audit/` and `config/` packages
- Documentation table updated with `config.yaml.example`

## Testing

`make gate` passes: build, vet, lint, vulncheck, tests (including new config + audit suites), binary smoke.