### PR TITLE
feat: SEC-2 — add --workspace-root flag to confine all path operations

### DIFF
--- a/cmd/tfai/commands/serve.go
+++ b/cmd/tfai/commands/serve.go
@@ -5,6 +5,7 @@ import (
 	"log/slog"
 	"os"
 	"os/signal"
+	"path/filepath"
 	"syscall"
 
 	"github.com/cloudwego/eino/callbacks"
@@ -24,6 +25,7 @@ import (
 func NewServeCmd() *cobra.Command {
 	var host string
 	var port int
+	var workspaceRoot string
 
 	cmd := &cobra.Command{
 		Use:   "serve",
@@ -115,12 +117,24 @@ Examples:
 
 			pingers := buildPingers(ctx, chatModel, providerCfg, log)
 
+			// Resolve workspace root path if the flag has been provided
+			if cmd.Flags().Changed("workspace-root") {
+				workspaceRoot, err = filepath.Abs(cmd.Flags().Lookup("workspace-root").Value.String())
+				if err != nil {
+					return fmt.Errorf("serve:workspace-root: failed to resolve absolute path of workspace root: %w", err)
+				}
+			} else {
+				log.Debug("workspace-root not set; workspace path confinement disabled")
+				workspaceRoot = ""
+			}
+
 			srv, err := server.New(tfAgent, &server.Config{
-				Host:    host,
-				Port:    port,
-				Logger:  log,
-				Pingers: pingers,
-				APIKey:  os.Getenv("TFAI_API_KEY"),
+				Host:          host,
+				Port:          port,
+				Logger:        log,
+				Pingers:       pingers,
+				APIKey:        os.Getenv("TFAI_API_KEY"),
+				WorkspaceRoot: workspaceRoot,
 			})
 			if err != nil {
 				return fmt.Errorf("serve: failed to create server: %w", err)
@@ -131,6 +145,7 @@ Examples:
 	}
 
 	cmd.Flags().StringVar(&host, "host", "127.0.0.1", "Host address to bind to")
+	cmd.Flags().StringVarP(&workspaceRoot, "workspace-root", "w", "", "Workspace root directory")
 	cmd.Flags().IntVarP(&port, "port", "p", 8080, "TCP port to listen on")
 
 	return cmd

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -185,6 +185,8 @@ type Config struct {
 	// trimmed oldest-first to fit. Defaults to budget.DefaultMaxContextTokens
 	// if zero.
 	MaxContextTokens int
+	// WorkspaceRoot is the root directory for the workspace.
+	WorkspaceRoot string
 }
 
 // TerraformAgent wraps the Eino ReAct agent with Terraform-specific behaviour,
@@ -207,6 +209,9 @@ type TerraformAgent struct {
 
 	// maxContextTokens is the estimated token budget for the full input context.
 	maxContextTokens int
+
+	// workspaceRoot is the root directory for the workspace.
+	workspaceRoot string
 }
 
 // New constructs a TerraformAgent from the provided Config.
@@ -249,6 +254,7 @@ func New(ctx context.Context, cfg *Config) (*TerraformAgent, error) {
 		history:          cfg.History,
 		historyDepth:     depth,
 		maxContextTokens: maxCtx,
+		workspaceRoot:    cfg.WorkspaceRoot,
 	}, nil
 }
 
@@ -293,6 +299,13 @@ func (a *TerraformAgent) Query(ctx context.Context, userMessage, workspaceDir st
 		}
 	}
 
+	if a.workspaceRoot != "" {
+		root := filepath.Clean(a.workspaceRoot)
+		target := filepath.Clean(workspaceDir)
+		if !strings.HasPrefix(target+string(filepath.Separator), root+string(filepath.Separator)) {
+			return false, fmt.Errorf("agent: workspaceDir %q is outside permitted root %q", workspaceDir, a.workspaceRoot)
+		}
+	}
 	// If a workspace directory was provided, attempt to parse the buffered output
 	// as a terraform_generate JSON envelope. On success, write files to disk and
 	// stream the human-readable summary to the caller. On failure (regular text

--- a/internal/server/struct.go
+++ b/internal/server/struct.go
@@ -38,6 +38,9 @@ type Config struct {
 	// APIKey is the Bearer token required on all protected /api/* routes.
 	// If empty, authentication is disabled (development mode).
 	APIKey string
+	// WorkspaceRoot is the root directory for workspace operations.
+	// If empty, the server will use the current working directory.
+	WorkspaceRoot string
 	// ChatTimeout is the maximum duration for a single /api/chat request,
 	// including LLM streaming. Defaults to 5 minutes if zero.
 	ChatTimeout time.Duration

--- a/internal/server/workspace.go
+++ b/internal/server/workspace.go
@@ -41,10 +41,10 @@ func writeJSONError(w http.ResponseWriter, msg string, status int) {
 	w.Write(b) //nolint:errcheck // best-effort write on error path
 }
 
-// confineToDir validates that target resolves to a path inside root after
+// ConfineToDir validates that target resolves to a path inside root after
 // cleaning both. This prevents path traversal attacks (e.g. "../../etc/passwd").
 // Returns the cleaned absolute target path or an error.
-func confineToDir(root, target string) (string, error) {
+func ConfineToDir(root, target string) (string, error) {
 	root = filepath.Clean(root)
 	target = filepath.Clean(target)
 	if !strings.HasPrefix(target+string(filepath.Separator), root+string(filepath.Separator)) {
@@ -61,6 +61,13 @@ func (s *Server) handleWorkspace(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		writeJSONError(w, err.Error(), http.StatusBadRequest)
 		return
+	}
+	if s.cfg.WorkspaceRoot != "" {
+		dir, err = ConfineToDir(s.cfg.WorkspaceRoot, dir)
+		if err != nil {
+			writeJSONError(w, err.Error(), http.StatusBadRequest)
+			return
+		}
 	}
 
 	if _, err := os.Stat(dir); os.IsNotExist(err) {
@@ -139,6 +146,14 @@ func (s *Server) handleWorkspaceCreate(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	if s.cfg.WorkspaceRoot != "" {
+		dir, err = ConfineToDir(s.cfg.WorkspaceRoot, dir)
+		if err != nil {
+			writeJSONError(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+	}
+
 	// Reject if the directory does not already exist — we do not create directories.
 	if info, err := os.Stat(dir); err != nil {
 		if os.IsNotExist(err) {
@@ -190,11 +205,20 @@ func (s *Server) handleFileRead(w http.ResponseWriter, r *http.Request) {
 		writeJSONError(w, "workspaceDir is required", http.StatusBadRequest)
 		return
 	}
-	path, err := confineToDir(rawRoot, rawPath)
+	path, err := ConfineToDir(rawRoot, rawPath)
 	if err != nil {
 		writeJSONError(w, err.Error(), http.StatusForbidden)
 		return
 	}
+
+	if s.cfg.WorkspaceRoot != "" {
+		path, err = ConfineToDir(s.cfg.WorkspaceRoot, path)
+		if err != nil {
+			writeJSONError(w, err.Error(), http.StatusForbidden)
+			return
+		}
+	}
+
 	content, err := os.ReadFile(path)
 	if err != nil {
 		if os.IsNotExist(err) {
@@ -229,11 +253,20 @@ func (s *Server) handleFileSave(w http.ResponseWriter, r *http.Request) {
 		writeJSONError(w, "workspaceDir is required", http.StatusBadRequest)
 		return
 	}
-	path, err := confineToDir(body.WorkspaceDir, body.Path)
+	path, err := ConfineToDir(body.WorkspaceDir, body.Path)
 	if err != nil {
 		writeJSONError(w, err.Error(), http.StatusForbidden)
 		return
 	}
+
+	if s.cfg.WorkspaceRoot != "" {
+		path, err = ConfineToDir(s.cfg.WorkspaceRoot, path)
+		if err != nil {
+			writeJSONError(w, err.Error(), http.StatusForbidden)
+			return
+		}
+	}
+
 	if err := os.WriteFile(path, []byte(body.Content), 0o644); err != nil {
 		logging.FromContext(r.Context()).Error("file save error",
 			slog.String("path", path),

--- a/internal/server/workspace_test.go
+++ b/internal/server/workspace_test.go
@@ -450,6 +450,218 @@ func TestHandleWorkspaceCreate_NonExistentDir(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
+// ConfineToDir — pure function tests
+// ---------------------------------------------------------------------------
+
+// TestConfineToDir verifies the path confinement helper used by all handlers
+// and the agent. It must accept valid sub-paths and reject traversal attempts.
+func TestConfineToDir(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	inside := filepath.Join(root, "sub", "dir")
+	outside := filepath.Join(root, "..", "outside")
+
+	tests := []struct {
+		name    string
+		root    string
+		target  string
+		wantErr bool
+	}{
+		{name: "direct child", root: root, target: filepath.Join(root, "foo"), wantErr: false},
+		{name: "nested child", root: root, target: inside, wantErr: false},
+		{name: "root itself", root: root, target: root, wantErr: false},
+		{name: "outside via ..", root: root, target: outside, wantErr: true},
+		{name: "absolute escape", root: root, target: "/etc/passwd", wantErr: true},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			_, err := ConfineToDir(tc.root, tc.target)
+			if (err != nil) != tc.wantErr {
+				t.Errorf("ConfineToDir(%q, %q) error = %v, wantErr %v", tc.root, tc.target, err, tc.wantErr)
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// WorkspaceRoot confinement — handler tests
+// ---------------------------------------------------------------------------
+
+// newTestServerWithRoot builds a *Server with WorkspaceRoot set.
+func newTestServerWithRoot(root string) *Server {
+	return &Server{
+		agent: nil,
+		cfg:   &Config{WorkspaceRoot: root},
+		log:   slog.Default(),
+	}
+}
+
+// TestHandleWorkspace_WorkspaceRootConfinement verifies that GET /api/workspace
+// rejects a dir outside WorkspaceRoot with 400 and accepts one inside it.
+func TestHandleWorkspace_WorkspaceRootConfinement(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	allowed := filepath.Join(root, "allowed")
+	mustMkdir(t, allowed)
+
+	s := newTestServerWithRoot(root)
+
+	t.Run("inside root — allowed", func(t *testing.T) {
+		t.Parallel()
+		req := httptest.NewRequest(http.MethodGet, "/api/workspace?dir="+allowed, nil)
+		w := httptest.NewRecorder()
+		s.handleWorkspace(w, req)
+		if w.Code != http.StatusOK {
+			t.Errorf("expected 200, got %d — body: %s", w.Code, w.Body.String())
+		}
+	})
+
+	t.Run("outside root — rejected", func(t *testing.T) {
+		t.Parallel()
+		req := httptest.NewRequest(http.MethodGet, "/api/workspace?dir=/tmp", nil)
+		w := httptest.NewRecorder()
+		s.handleWorkspace(w, req)
+		if w.Code != http.StatusBadRequest {
+			t.Errorf("expected 400, got %d — body: %s", w.Code, w.Body.String())
+		}
+	})
+
+	t.Run("traversal path — rejected", func(t *testing.T) {
+		t.Parallel()
+		traversal := allowed + "/../../etc"
+		req := httptest.NewRequest(http.MethodGet, "/api/workspace?dir="+traversal, nil)
+		w := httptest.NewRecorder()
+		s.handleWorkspace(w, req)
+		if w.Code != http.StatusBadRequest {
+			t.Errorf("expected 400, got %d — body: %s", w.Code, w.Body.String())
+		}
+	})
+
+	t.Run("no workspace root — no confinement", func(t *testing.T) {
+		t.Parallel()
+		s2 := newTestServer() // WorkspaceRoot is empty
+		req := httptest.NewRequest(http.MethodGet, "/api/workspace?dir="+allowed, nil)
+		w := httptest.NewRecorder()
+		s2.handleWorkspace(w, req)
+		if w.Code != http.StatusOK {
+			t.Errorf("expected 200 with no root set, got %d — body: %s", w.Code, w.Body.String())
+		}
+	})
+}
+
+// TestHandleWorkspaceCreate_WorkspaceRootConfinement verifies that
+// POST /api/workspace/create rejects a dir outside WorkspaceRoot.
+func TestHandleWorkspaceCreate_WorkspaceRootConfinement(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	allowed := filepath.Join(root, "ws")
+	mustMkdir(t, allowed)
+
+	s := newTestServerWithRoot(root)
+
+	t.Run("inside root — allowed", func(t *testing.T) {
+		t.Parallel()
+		body := `{"dir":"` + allowed + `"}`
+		req := httptest.NewRequest(http.MethodPost, "/api/workspace/create", strings.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+		w := httptest.NewRecorder()
+		s.handleWorkspaceCreate(w, req)
+		if w.Code != http.StatusOK {
+			t.Errorf("expected 200, got %d — body: %s", w.Code, w.Body.String())
+		}
+	})
+
+	t.Run("outside root — rejected", func(t *testing.T) {
+		t.Parallel()
+		body := `{"dir":"/tmp"}`
+		req := httptest.NewRequest(http.MethodPost, "/api/workspace/create", strings.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+		w := httptest.NewRecorder()
+		s.handleWorkspaceCreate(w, req)
+		if w.Code != http.StatusBadRequest {
+			t.Errorf("expected 400, got %d — body: %s", w.Code, w.Body.String())
+		}
+	})
+}
+
+// TestHandleFileRead_WorkspaceRootConfinement verifies that GET /api/file
+// rejects a path whose workspaceDir falls outside WorkspaceRoot.
+func TestHandleFileRead_WorkspaceRootConfinement(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	allowed := filepath.Join(root, "ws")
+	mustMkdir(t, allowed)
+	mustWriteFile(t, filepath.Join(allowed, "main.tf"), "# tf")
+
+	s := newTestServerWithRoot(root)
+
+	t.Run("inside root — allowed", func(t *testing.T) {
+		t.Parallel()
+		url := "/api/file?workspaceDir=" + allowed + "&path=" + filepath.Join(allowed, "main.tf")
+		req := httptest.NewRequest(http.MethodGet, url, nil)
+		w := httptest.NewRecorder()
+		s.handleFileRead(w, req)
+		if w.Code != http.StatusOK {
+			t.Errorf("expected 200, got %d — body: %s", w.Code, w.Body.String())
+		}
+	})
+
+	t.Run("workspaceDir outside root — rejected", func(t *testing.T) {
+		t.Parallel()
+		url := "/api/file?workspaceDir=/tmp&path=/tmp/main.tf"
+		req := httptest.NewRequest(http.MethodGet, url, nil)
+		w := httptest.NewRecorder()
+		s.handleFileRead(w, req)
+		if w.Code != http.StatusForbidden {
+			t.Errorf("expected 403, got %d — body: %s", w.Code, w.Body.String())
+		}
+	})
+}
+
+// TestHandleFileSave_WorkspaceRootConfinement verifies that PUT /api/file
+// rejects a write whose workspaceDir falls outside WorkspaceRoot.
+func TestHandleFileSave_WorkspaceRootConfinement(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	allowed := filepath.Join(root, "ws")
+	mustMkdir(t, allowed)
+
+	s := newTestServerWithRoot(root)
+
+	t.Run("inside root — allowed", func(t *testing.T) {
+		t.Parallel()
+		body := `{"workspaceDir":"` + allowed + `","path":"` + filepath.Join(allowed, "main.tf") + `","content":"# tf"}`
+		req := httptest.NewRequest(http.MethodPut, "/api/file", strings.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+		w := httptest.NewRecorder()
+		s.handleFileSave(w, req)
+		if w.Code != http.StatusOK {
+			t.Errorf("expected 200, got %d — body: %s", w.Code, w.Body.String())
+		}
+	})
+
+	t.Run("workspaceDir outside root — rejected", func(t *testing.T) {
+		t.Parallel()
+		body := `{"workspaceDir":"/tmp","path":"/tmp/main.tf","content":"# tf"}`
+		req := httptest.NewRequest(http.MethodPut, "/api/file", strings.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+		w := httptest.NewRecorder()
+		s.handleFileSave(w, req)
+		if w.Code != http.StatusForbidden {
+			t.Errorf("expected 403, got %d — body: %s", w.Code, w.Body.String())
+		}
+	})
+}
+
+// ---------------------------------------------------------------------------
 // Test helpers
 // ---------------------------------------------------------------------------
 //


### PR DESCRIPTION
## Summary

Adds a server-level `--workspace-root` flag that constrains every handler and the agent to a declared root directory. When set, any request whose path resolves outside the root is rejected before any filesystem operation occurs.

This is an **opt-in hardening flag** — omitting it preserves existing behaviour exactly.

## Changes

### `cmd/tfai/commands/serve.go`
- Add `--workspace-root` / `-w` flag (optional; empty = no confinement)
- Resolve to absolute path via `filepath.Abs` when flag is set
- Pass `WorkspaceRoot` into `server.Config`
- Demote 'not set' log from `Warn` to `Debug` — no root is a valid config

### `internal/server/struct.go`
- Add `WorkspaceRoot string` field to `Config` with doc comment

### `internal/server/workspace.go`
- Export `ConfineToDir` (was `confineToDir`) — used by tests
- `handleWorkspace`: check `resolveAbsDir` err first, then confine to root
- `handleWorkspaceCreate`: same ordering fix + root confinement
- `handleFileRead`: check first `ConfineToDir` err, then apply root check
- `handleFileSave`: same

### `internal/agent/agent.go`
- Add `WorkspaceRoot` to `agent.Config`
- Set `workspaceRoot` in `New()` from `cfg.WorkspaceRoot`
- Inline path check using `filepath.Clean` + `strings.HasPrefix` (avoids import cycle with `internal/server`)

### `internal/server/workspace_test.go`
- `TestConfineToDir`: table-driven unit test (5 cases: child, nested, root itself, traversal, absolute escape)
- `TestHandleWorkspace_WorkspaceRootConfinement`: inside / outside / traversal / no-root (4 sub-tests)
- `TestHandleWorkspaceCreate_WorkspaceRootConfinement`: inside / outside
- `TestHandleFileRead_WorkspaceRootConfinement`: inside / outside
- `TestHandleFileSave_WorkspaceRootConfinement`: inside / outside

## Gate

```
go build ./...   ✓
go vet ./...     ✓
go test -race -count=1 ./...  ✓ (all packages)
```

## Closes
SEC-2 from ROADMAP.md