### PR TITLE
chore(ci): add binary smoke tests, RC release support, and docs updates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,13 +22,23 @@ jobs:
           cache: true
 
       - name: go build
-        run: go build ./...
+        run: go build -trimpath -o bin/tfai ./cmd/tfai
 
       - name: go vet
         run: go vet ./...
 
       - name: go test (race)
         run: go test -race -count=1 ./...
+
+      # Binary smoke tests - verify the built binary actually runs
+      - name: Smoke test - version
+        run: ./bin/tfai version
+
+      - name: Smoke test - help
+        run: ./bin/tfai --help
+
+      - name: Smoke test - serve help
+        run: ./bin/tfai serve --help
 
   lint:
     name: Lint

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,9 +31,17 @@ jobs:
       - name: Set version variables
         id: vars
         run: |
-          echo "VERSION=${GITHUB_REF_NAME}" >> "$GITHUB_OUTPUT"
+          VERSION="${GITHUB_REF_NAME}"
+          echo "VERSION=${VERSION}" >> "$GITHUB_OUTPUT"
           echo "COMMIT=$(git rev-parse --short HEAD)" >> "$GITHUB_OUTPUT"
           echo "BUILD_DATE=$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> "$GITHUB_OUTPUT"
+
+          # Detect if this is a pre-release (rc, alpha, beta)
+          if [[ "$VERSION" =~ -(rc|alpha|beta) ]]; then
+            echo "PRERELEASE=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "PRERELEASE=false" >> "$GITHUB_OUTPUT"
+          fi
 
       # Run the full test gate before releasing — never ship a broken binary.
       - name: go build (verify)
@@ -41,6 +49,11 @@ jobs:
 
       - name: go vet
         run: go vet ./...
+
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v7
+        with:
+          version: latest
 
       - name: go test (race)
         run: go test -race -count=1 ./...
@@ -74,10 +87,12 @@ jobs:
           cat checksums.txt
 
       # Create the GitHub Release and attach all binaries + checksums.
+      # Pre-releases (rc, alpha, beta) are marked as such and won't show as "latest".
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
         with:
           name: ${{ steps.vars.outputs.VERSION }}
+          prerelease: ${{ steps.vars.outputs.PRERELEASE == 'true' }}
           generate_release_notes: true # auto-generates notes from merged PRs/commits
           files: |
             dist/tfai-linux-amd64

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -271,7 +271,64 @@ Items that exist in this roadmap but have **no GitHub issue yet**:
 
 ---
 
-## 8. How to Update This File
+## 8. How to Release
+
+### Versioning Convention
+
+| Change Type | Version Bump | Example |
+|---|---|---|
+| Breaking changes | Major (when v1+) | v1.0.0 → v2.0.0 |
+| New features | Minor | v0.29.0 → v0.30.0 |
+| Bug fixes only | Patch | v0.29.0 → v0.29.1 |
+| Pre-release testing | RC suffix | v0.30.0-rc.1 |
+
+### Release Checklist
+
+```bash
+# 1. Ensure you're on main with all changes merged
+git checkout main && git pull
+
+# 2. Run the full gate locally — must pass
+make gate
+
+# 3. Update this file (docs/ROADMAP.md)
+#    - Add entry to Release History table
+#    - Update "Current version" at top
+#    - Mark completed items in audit sections
+
+# 4. Commit the release prep
+git add docs/ROADMAP.md
+git commit -m "chore: prepare vX.Y.Z release"
+git push
+
+# 5. Create and push the tag
+git tag vX.Y.Z
+git push --tags
+
+# 6. Verify the release
+#    - Check GitHub Actions: release workflow should trigger
+#    - Check GitHub Releases: binaries and checksums attached
+#    - Download and test a binary on your platform
+```
+
+### Tag Format
+
+Tags **must** follow semantic versioning: `vMAJOR.MINOR.PATCH` or `vMAJOR.MINOR.PATCH-rc.N`
+
+- ✅ `v0.30.0`, `v1.0.0`, `v0.30.0-rc.1`
+- ❌ `v0.30`, `0.30.0`, `release-0.30.0`
+
+### What the Release Workflow Does
+
+1. Validates the tag format
+2. Runs full test suite (build, vet, lint, test)
+3. Builds binaries for: linux/amd64, linux/arm64, darwin/amd64, darwin/arm64, windows/amd64
+4. Generates SHA256 checksums
+5. Creates GitHub Release with auto-generated notes from merged PRs
+
+---
+
+## 9. How to Update This File
 
 1. After every merge to `main`: update the **Release History** table and mark completed items.
 2. After creating a GitHub issue: add the issue number to the relevant row.

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -34,7 +34,7 @@
 - **Go 1.26+**: `go version`
 - **golangci-lint**: `golangci-lint --version`
 - **govulncheck**: `govulncheck -version` (install: `go install golang.org/x/vuln/cmd/govulncheck@latest`)
-- **A configured LLM provider** (see `.env.example`). Ollama is easiest for local testing.
+- **A configured LLM provider** (see `config.yaml.example` for settings, `.env.example` for API keys). Ollama is easiest for local testing.
 
 ### Optional (for full stack)
 
@@ -48,9 +48,13 @@
 # Clone and enter the repo
 cd /path/to/tfai-go
 
-# Copy env template and configure your provider
+# 1. Copy and configure settings (non-secrets)
+cp config.yaml.example config.yaml
+# Edit config.yaml — set model.provider and other settings
+
+# 2. Copy and configure secrets (API keys only)
 cp .env.example .env
-# Edit .env — at minimum set MODEL_PROVIDER and model-specific vars
+# Edit .env — uncomment and set API keys for your provider
 
 # Install dev tools (one-time)
 make install-tools
@@ -58,6 +62,10 @@ make install-tools
 # Download Go dependencies
 make deps
 ```
+
+> **Configuration model**: `config.yaml` is the primary configuration file.
+> `.env` holds secrets only (API keys, tokens). Environment variables override
+> `config.yaml` values when set. See README for full details.
 
 ---
 
@@ -125,6 +133,16 @@ make fmt            # format all files (gofmt + goimports)
 
 These tests verify each CLI command works end-to-end. **Requires a configured LLM provider.**
 
+### Global Flags
+
+All commands support these global flags:
+
+| Flag | Description |
+|---|---|
+| `--config <path>` | Path to YAML config file (default: `~/.tfai/config.yaml`) |
+
+The config file search order is: `--config` flag → `$TFAI_CONFIG` env var → `~/.tfai/config.yaml` → `./tfai.yaml`
+
 ### 3.1 Version
 
 ```bash
@@ -133,8 +151,10 @@ These tests verify each CLI command works end-to-end. **Requires a configured LL
 
 **Expected:** Version string with commit hash and build date:
 ```
-tfai v0.18.0 (commit: abc1234, built: 2026-02-20T22:00:00Z)
+tfai v0.29.0 (commit: abc1234, built: 2026-02-24T12:00:00Z)
 ```
+
+> **Note:** Development builds show `-dirty` suffix and additional git info.
 
 ### 3.2 Ask
 
@@ -350,17 +370,26 @@ unset GENERATE_MODEL_PROVIDER GENERATE_MODEL GENERATE_AZURE_DEPLOYMENT GENERATE_
 ### 4.1 Start the server
 
 ```bash
-# Terminal 1: start the server
+# Terminal 1: start the server (uses config.yaml or env vars)
 ./bin/tfai serve
+
+# Or with explicit config file
+./bin/tfai serve --config ./my-config.yaml
+
+# Or with workspace confinement (all file operations restricted to this dir)
+./bin/tfai serve --workspace-root /path/to/terraform/projects
 ```
 
 **Expected log output:**
+```json
+{"time":"...","level":"INFO","msg":"audit: command start","command":"serve",...}
+{"time":"...","level":"INFO","msg":"serve starting","provider":"ollama"}
+{"time":"...","level":"WARN","msg":"auth disabled: TFAI_API_KEY not set — all API routes are unauthenticated"}
+{"time":"...","level":"INFO","msg":"provider initialised","provider":"ollama"}
+{"time":"...","level":"INFO","msg":"server listening","addr":"http://127.0.0.1:8080"}
 ```
-{"level":"INFO","msg":"serve starting","provider":"ollama"}
-{"level":"WARN","msg":"auth disabled: TFAI_API_KEY not set — all API routes are unauthenticated"}
-{"level":"INFO","msg":"provider initialised","provider":"ollama"}
-{"level":"INFO","msg":"server listening","addr":"http://127.0.0.1:8080"}
-```
+
+> **Note:** The first log line is the audit log showing sanitized config state.
 
 ### 4.2 Liveness probe
 


### PR DESCRIPTION
---                                                                                                                                                                                                                  
Summary                                                                                                                                                                                                              
                                                                                                                                                                                                                   
- Add binary smoke tests to CI workflow to catch runtime failures early                                                                                                                                              
- Enhance release workflow with lint checks and RC/pre-release support
- Document the release process in ROADMAP.md
- Update TESTING.md for YAML-first config approach                                                                                                                                                                   
                                                                                                                                                                                                                   
Changes                                                                                                                                                                                                              
                                                                                                                                                                                                                   
CI Workflow

- Binary smoke tests now run after build (tfai version, tfai --help, tfai serve --help)
- Catches issues where code compiles but binary fails to run

Release Workflow

- Added golangci-lint step before creating releases
- RC tags (v0.30.0-rc.1, -alpha, -beta) are automatically detected and marked as pre-releases
- Pre-releases won't appear as "latest" in GitHub Releases

Documentation

- ROADMAP.md: New "How to Release" section with versioning convention, release checklist, and tag format guidance
- TESTING.md: Updated to reflect YAML-first config approach, added Global Flags section, updated server startup examples with --config and --workspace-root flags

Test Plan

- CI workflow passes with new smoke tests
- Verify lint step appears in release workflow
- Review ROADMAP.md release documentation
- Review TESTING.md for accuracy