### PR TITLE
fix(smoke-test-regressions): smoke test regressions — double path in generate, version pre-run skip, docs, tooling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,6 @@ workspace/
 
 # Qdrant local data (if running outside docker)
 qdrant_storage/
+
+# server config
+config.yaml

--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,7 @@ deps: ## Download and tidy Go module dependencies
 
 .PHONY: install-tools
 install-tools: ## Install local development tools (golangci-lint, goimports, govulncheck)
-	$(GO) install github.com/golangci/golangci-lint/cmd/golangci-lint@latest
+	$(GO) install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@latest
 	$(GO) install golang.org/x/tools/cmd/goimports@latest
 	$(GO) install golang.org/x/vuln/cmd/govulncheck@latest
 
@@ -55,6 +55,10 @@ build: ## Build the tfai binary natively (version info injected via ldflags)
 .PHONY: version
 version: build ## Print the version of the locally built binary
 	./bin/$(BINARY) version
+
+.PHONY: install
+install: ## Install tfai binary to $GOPATH/bin with version info (ldflags)
+	$(GO) install $(GOFLAGS) -trimpath -ldflags="$(LD_FLAGS)" ./cmd/tfai
 
 .PHONY: build-docker
 build-docker: ## Build the Docker image

--- a/cmd/tfai/commands/version.go
+++ b/cmd/tfai/commands/version.go
@@ -15,6 +15,9 @@ func NewVersionCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:   "version",
 		Short: "Print the tfai version, git commit, and build date",
+		// PersistentPreRunE is overridden to skip config load and audit logging.
+		// version is a pure info command that requires no environment setup.
+		PersistentPreRunE: func(_ *cobra.Command, _ []string) error { return nil },
 		Run: func(cmd *cobra.Command, args []string) {
 			fmt.Printf("tfai %s (commit: %s, built: %s)\n",
 				version.Version, version.Commit, version.BuildDate)

--- a/config.yaml.example
+++ b/config.yaml.example
@@ -62,6 +62,6 @@ history:
   # db_path: disabled      # set to "disabled" to turn off
 
 # tracing:
-#   public_key: ""         # prefer LANGFUSE_PUBLIC_KEY env var
-#   secret_key: ""         # prefer LANGFUSE_SECRET_KEY env var
-#   host: ""               # prefer LANGFUSE_HOST env var
+#   public_key: ""                # prefer LANGFUSE_PUBLIC_KEY env var
+#   secret_key: ""                # prefer LANGFUSE_SECRET_KEY env var
+#   host: "http://localhost:3000" # prefer LANGFUSE_HOST env var

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -159,6 +159,7 @@ echo 'resource "aws_s3_bucket" "test" { bucket = "my-bucket" }' > /tmp/tfai-test
 ### 3.4 Generate
 
 ```bash
+mkdir -p /tmp/tfai-gen-test
 ./bin/tfai generate --out /tmp/tfai-gen-test "S3 bucket with versioning and server-side encryption"
 ```
 

--- a/internal/agent/apply.go
+++ b/internal/agent/apply.go
@@ -13,7 +13,16 @@ func applyFiles(output *TerraformAgentOutput, workspaceDir string) error {
 
 	// Loop over output.Files output by the agent and add them to filesystem
 	for _, file := range output.Files {
-		filePath := filepath.Join(root, file.Path)
+		// Defensive: strip the workspace root prefix if the LLM echoed it back
+		// in the file path. Without this, --out /tmp/foo with an LLM path of
+		// "/tmp/foo/main.tf" would produce /tmp/foo/tmp/foo/main.tf.
+		cleanPath := filepath.Clean(file.Path)
+		cleanPath = strings.TrimPrefix(cleanPath, root)
+		cleanPath = strings.TrimPrefix(cleanPath, string(filepath.Separator))
+		if cleanPath == "" || cleanPath == "." {
+			continue
+		}
+		filePath := filepath.Join(root, cleanPath)
 		// Separator-aware prefix check prevents /tmp/foo matching /tmp/foobar.
 		if !strings.HasPrefix(filePath+string(filepath.Separator), root+string(filepath.Separator)) {
 			return fmt.Errorf("agent::applyFiles: file path %s is outside workspace %s", filePath, root)

--- a/internal/agent/apply_test.go
+++ b/internal/agent/apply_test.go
@@ -107,10 +107,11 @@ func TestApplyFilesNoPathDoubling(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name      string
-		filePath  string // path returned by the LLM in the JSON envelope
-		wantFile  string // expected file location relative to workspace root
-		wantError bool
+		name           string
+		filePath       string // path returned by the LLM in the JSON envelope
+		wantFile       string // expected file location relative to workspace root
+		wantError      bool
+		prefixWithRoot bool // if true, filePath is prefixed with the temp dir to simulate LLM echoing the absolute path
 	}{
 		{
 			name:     "relative path — no doubling",
@@ -127,6 +128,18 @@ func TestApplyFilesNoPathDoubling(t *testing.T) {
 			filePath: "mydir/main.tf",
 			wantFile: "mydir/main.tf",
 		},
+		{
+			name:           "llm echoes absolute workspace root — stripped",
+			filePath:       "main.tf",
+			wantFile:       "main.tf",
+			prefixWithRoot: true,
+		},
+		{
+			name:           "llm echoes absolute workspace root with subdir — stripped",
+			filePath:       "modules/eks/main.tf",
+			wantFile:       "modules/eks/main.tf",
+			prefixWithRoot: true,
+		},
 	}
 
 	for _, tc := range tests {
@@ -134,9 +147,13 @@ func TestApplyFilesNoPathDoubling(t *testing.T) {
 			t.Parallel()
 
 			dir := t.TempDir()
+			fp := tc.filePath
+			if tc.prefixWithRoot {
+				fp = filepath.Join(dir, tc.filePath)
+			}
 			output := &TerraformAgentOutput{
 				Summary: "regression: " + tc.name,
-				Files:   []GeneratedFile{{Path: tc.filePath, Content: "# content"}},
+				Files:   []GeneratedFile{{Path: fp, Content: "# content"}},
 			}
 
 			err := applyFiles(output, dir)


### PR DESCRIPTION
## Summary

Fixes several issues found during manual smoke testing.

### Changes

**Bug fixes:**
- **fix(agent):** Strip workspace root prefix from LLM-returned file paths in `applyFiles` to prevent path doubling (e.g. `--out /tmp/foo` writing to `/tmp/foo/tmp/foo/main.tf`). Adds regression tests for LLM echoing absolute workspace root.
- **fix(version):** Override `PersistentPreRunE` with no-op so `tfai version` skips audit log and config load — enables clean piping (`tfai version | grep ...`). Related: #60

**Tooling:**
- **feat(Makefile):** Add `install` target with ldflags for `go install` to `$GOPATH/bin`
- **chore(Makefile):** Upgrade `golangci-lint` install to v2 module path

**Docs & config:**
- **docs(TESTING.md):** Add missing `mkdir -p` instruction in §3.4 Generate
- **chore(config.yaml.example):** Align tracing section formatting
- **chore(.gitignore):** Exclude `config.yaml` (contains local secrets)

### Testing

- `make gate` PASS (build, vet, lint, vulncheck, test, binary smoke)
- New regression tests: `TestApplyFilesNoPathDoubling` with `prefixWithRoot` cases